### PR TITLE
ignore 'sandbox' too

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -26,8 +26,8 @@ commands=
 
 [flake8]
 max-line-length = 160
-exclude = .ropeproject,.tox
+exclude = .ropeproject,.tox,sandbox
 show-source = True
 
 [pytest]
-norecursedirs = .tox .git .hg
+norecursedirs = .tox .git .hg sandbox


### PR DESCRIPTION
I keep my virtualenvs in a 'sandbox' subdirectory of the working directory.  Without this change, tox has pep8 and pytest recurse into that directory and run a lot of (failing) tests for installed packages.  This shouldn't hurt elsewhere.