### PR TITLE
Bug 1116271: Manage the Releng Network in us-west-2

### DIFF
--- a/configs/cloudformation/README.md
+++ b/configs/cloudformation/README.md
@@ -1,0 +1,47 @@
+# CloudFormation Templates
+
+This directory contains a number of [CloudFormation templates](http://aws.amazon.com/documentation/cloudformation/) expressed in [cfn-pyplates](https://cfn-pyplates.readthedocs.org/en/latest/) format.
+Taken together, these templates define the releng cloud infrastructure.
+
+The templates are tied to stacks and to one another with `stacks.yml`.
+See that file for a list of stacks that can be deployed.
+
+## Deploying
+
+To deploy a stack, use the `aws_deploy_cloudformation` script in this repo:
+
+    aws_deploy_cloudformation --wait MyStackName
+
+The script has a number of other options; see its `--help` for details.
+
+## Hacking
+
+### Stacks
+
+The format of `stacks.yml` is as follows:
+
+ * `stacks`
+
+    * *Stack name* -- note that these must be unique across all regions.
+      Since most stacks will be duplicated in all regions, add a short region suffix (`Usw1`, `Usw2`, or `Use1`) to the stack name.
+
+      * `region`: *region name* -- the long region name in which this stack is deployed (e.g., `us-east-1`)
+      * `template`: *template filename* -- the filename of the template that defines this stack
+      * `options`: *option dictionary* -- an arbitrary dictionary that will be available to the template as `options`.
+        This is *not* the same thing as parameters, although it is often more useful; see the pyplates documentation for details.
+
+### Future Plans
+
+ * Ability to reference resource in other stacks
+ * Support for parameters
+ * Automatic region suffixes
+
+### Templates
+
+To modify the templates themselves, you'll need to know Python and [cfn-pyplates](https://cfn-pyplates.readthedocs.org/en/latest/).
+We do a few things "uniquely", though:
+
+ * All Python objects should be explicitly imported (this keeps flake8 happy)
+ * In many cases, objects are created by Python code, rather than being listed out.
+   [Dont' repeat yourself](http://en.wikipedia.org/wiki/Don%27t_repeat_yourself).
+   This makes the templates a little harder for a non-Pythonista to read, but that's OK.

--- a/configs/cloudformation/network.py
+++ b/configs/cloudformation/network.py
@@ -2,13 +2,292 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from cfn_pyplates.core import CloudFormationTemplate, Resource, Properties
+import dns.resolver
+import itertools
+import re
+from IPy import IP
+from cfn_pyplates.core import CloudFormationTemplate, Resource
+from cfn_pyplates.core import Properties, options, DependsOn
+from cfn_pyplates.functions import ref
+
+# Parameters
+
+region_prefixes = {
+    'usw1': '10.130',
+}
+
+# Fn::GetAZs is great, but there's no Fn::Len or modulus operation.
+# So we just hard-code it here.
+availability_zones = {
+    'usw1': ['us-west-1a', 'us-west-1b'],
+}
+
+# Subnets that belong to Amazon.  We get much better performance if these are
+# routed via the internet gateway.  `whois` is useful for checking netblock
+# sizes when you spot a new IP range.
+
+amazon_cidrs = [
+    "50.16.0.0/14",
+    "54.230.0.0/15",
+    "54.239.0.0/17",
+    "54.240.0.0/12",
+    "72.21.192.0/19",
+    "176.32.96.0/21",
+    "178.236.0.0/21",
+    "205.251.192.0/18",
+    "207.171.160.0/19",
+]
+
+# all A records corresponding to these hosts should be
+# routed via the internet gateway, saving bandwidth
+igw_routed_hosts = [
+    'ftp-ssl.mozilla.org',
+    'hg.mozilla.org',
+    'git.mozilla.org',
+    'carbon.hostedgraphite.com',
+    'mozilla.carbon.hostedgraphite.com',
+]
+
+# Utility Functions
+
+
+def subnet_cidr(suffix, length):
+    prefix = region_prefixes[options['region']]
+    return '{}.{}/{}'.format(prefix, suffix, length)
+
+
+def subnet_az(index):
+    azs = availability_zones[options['region']]
+    return azs[index % len(azs)]
+
+
+def nametag(name):
+    return {'Key': 'Name', 'Value': name}
+
+
+def resolve_host(hostname):
+    ips = dns.resolver.query(hostname, "A")
+    # sort these so that we deterministically set up the same route
+    # resources (until DNS changes)
+    ips = sorted([i.to_text() for i in ips])
+    return ips
+
+# VPC
 
 cft = CloudFormationTemplate(description="Release Engineering network configuration")
 
-cft.resources.vpc = Resource(
+cft.resources.add(Resource(
     'RelengVPC', 'AWS::EC2::VPC',
     Properties({
-        'CidrBlock': '192.168.1.0/24',
+        'CidrBlock': subnet_cidr('0.0', 16),
+        'Tags': [nametag('Releng Network')],
     })
-)
+))
+
+# DHCP options
+
+cft.resources.add(Resource(
+    'DHCPOptions', 'AWS::EC2::DHCPOptions',
+    Properties({
+        # point to the onsite, IT-managed DNS servers
+        'DomainNameServers': [
+            "10.26.75.40",
+            "10.26.75.41"
+        ],
+        'Tags': [nametag('Releng Network Options')],
+    })
+))
+
+cft.resources.add(Resource(
+    'DHCPOptionsAssociation', 'AWS::EC2::VPCDHCPOptionsAssociation',
+    Properties({
+        'VpcId': ref('RelengVPC'),
+        'DhcpOptionsId': ref('DHCPOptions'),
+    })
+))
+
+# Internet Gateway
+
+cft.resources.add(Resource(
+    'IGW', 'AWS::EC2::InternetGateway',
+    Properties({
+        'Tags': [nametag('IGW for Releng VPC')],
+    })
+))
+
+cft.resources.add(Resource(
+    'IGWAttachment', 'AWS::EC2::VPCGatewayAttachment',
+    Properties({
+        'VpcId': ref('RelengVPC'),
+        'InternetGatewayId': ref('IGW'),
+    })
+))
+
+# Customer Gateway (tunnel to scl3)
+
+cft.resources.add(Resource(
+    'Scl3CustomerGateway', 'AWS::EC2::CustomerGateway',
+    Properties({
+        'Type': 'ipsec.1',
+        # XXX should be .82, but using that will "adopt" the existing, production CGW
+        'IpAddress': '63.245.214.99',
+        'BgpAsn': '99999',  # XXX should be 65026, same
+    })
+))
+
+cft.resources.add(Resource(
+    'Scl3VPNGateway', 'AWS::EC2::VPNGateway',
+    Properties({
+        'Type': 'ipsec.1',
+    })
+))
+
+cft.resources.add(Resource(
+    'Scl3VPNConnection', 'AWS::EC2::VPNConnection',
+    Properties({
+        'Type': 'ipsec.1',
+        'VpnGatewayId': ref('Scl3VPNGateway'),
+        'CustomerGatewayId': ref('Scl3CustomerGateway'),
+    })
+))
+
+cft.resources.add(Resource(
+    'Scl3VPCGatewayAttachment', 'AWS::EC2::VPCGatewayAttachment',
+    Properties({
+        'VpnGatewayId': ref('Scl3VPNGateway'),
+        'VpcId': ref('RelengVPC'),
+    })
+))
+
+
+# Subnets
+
+# `ip_space` is a list of (suffix, length) tuples.  suffix octet is appended to
+# the region prefix, so for example ('72.0', 23) in usw1 would generate
+# 10.130.72.0/23.  `split_to_length` says that multiple subnets should be
+# created distributed over the available AZ's, each with that subnet length.
+
+subnets = [
+    {
+        'name': 'srv',
+        'ip_space': [('48.0', 22)],
+        'split_to_length': 24,
+    },
+    {
+        'name': 'build',
+        'ip_space': [('52.0', 22)],
+        'split_to_length': 24,
+    },
+    {
+        'name': 'test',
+        'ip_space': [('56.0', 22), (156, 22)],
+        'split_to_length': 24,
+    },
+    {
+        'name': 'try',
+        'ip_space': [('64.0', 22)],
+        'split_to_length': 24,
+    },
+    {
+        'name': 'bb',
+        'ip_space': [('68.0', 24)],
+        'split_to_length': 26,  # only a /24, so split to /26
+    },
+]
+
+for subnet in subnets:
+    # split down to the right length
+    ip_prefix = region_prefixes[options['region']]
+    split_to_length = subnet['split_to_length']
+    # figure out the IP count of a subnet of the given size
+    split_to_increment = 2 ** (32 - split_to_length)
+    azs = iter(itertools.cycle(availability_zones[options['region']]))
+    counter = iter(itertools.count(1))
+    for ip_suffix, length in subnet['ip_space']:
+        ip_space = IP(subnet_cidr(ip_suffix, length))
+        subnet_space = IP(subnet_cidr(ip_suffix, split_to_length))
+        while subnet_space in ip_space:
+            subnet_name = 'Subnet{}{}'.format(subnet['name'].title(),
+                                              counter.next())
+            cft.resources.add(Resource(
+                subnet_name, 'AWS::EC2::Subnet',
+                Properties({
+                    'AvailabilityZone': azs.next(),
+                    'CidrBlock': str(subnet_space),
+                    'VpcId': ref('RelengVPC'),
+                    'Tags': [nametag(subnet['name'])],
+                })
+            ))
+
+            cft.resources.add(Resource(
+                subnet_name + 'RouteTableAssoc',
+                'AWS::EC2::SubnetRouteTableAssociation',
+                Properties({
+                    'SubnetId': ref(subnet_name),
+                    'RouteTableId': ref('VpcRouteTable'),
+                })
+            ))
+
+            # move to the next subnet space
+            subnet_space = IP('{}/{}'.format(
+                subnet_space.int() + split_to_increment,
+                split_to_length))
+
+# Route Table
+
+cft.resources.add(Resource(
+    'VpcRouteTable', 'AWS::EC2::RouteTable',
+    Properties({
+        'VpcId': ref('RelengVPC'),
+        'Tags': [nametag('Releng VPC Route Table')],
+    })
+))
+
+cft.resources.add(Resource(
+    'VPCToScl3', 'AWS::EC2::Route',
+    Properties({
+        'DestinationCidrBlock': '0.0.0.0/0',
+        'GatewayId': ref('Scl3VPNGateway'),
+        'RouteTableId': ref('VpcRouteTable'),
+    }),
+    DependsOn(['Scl3VPNConnection', 'Scl3VPCGatewayAttachment']),
+))
+
+for n, cidr in enumerate(amazon_cidrs, 1):
+    cft.resources.add(Resource(
+        'VPCToAWS{}'.format(n), 'AWS::EC2::Route',
+        Properties({
+            'DestinationCidrBlock': cidr,
+            'GatewayId': ref('IGW'),
+            'RouteTableId': ref('VpcRouteTable'),
+        }),
+        DependsOn(['IGW', 'IGWAttachment']),
+    ))
+
+cft.resources.add(Resource(
+    'VPCToGitHub', 'AWS::EC2::Route',
+    Properties({
+        # GitHub's subnet, per
+        # https://help.github.com/articles/what-ip-addresses-does-github-use-that-i-should-whitelist/
+        'DestinationCidrBlock': '192.30.252.0/22',
+        'GatewayId': ref('IGW'),
+        'RouteTableId': ref('VpcRouteTable'),
+    }),
+    DependsOn('IGW'),
+))
+
+for hostname in igw_routed_hosts:
+    camelcaps = ''.join(a.title() for a in re.split('[^a-z0-9]', hostname))
+    for ip in resolve_host(hostname):
+        ip_digits = ip.replace('.', '')
+        # build a resource name out of the hostname and IP.  It's ugly, but
+        # fairly unique.
+        cft.resources.add(Resource(
+            camelcaps + ip_digits, 'AWS::EC2::Route',
+            Properties({
+                'DestinationCidrBlock': '{}/32'.format(ip),
+                'GatewayId': ref('IGW'),
+                'RouteTableId': ref('VpcRouteTable'),
+            }),
+            DependsOn('IGW'),
+        ))

--- a/configs/cloudformation/stacks.yml
+++ b/configs/cloudformation/stacks.yml
@@ -3,6 +3,7 @@ stacks:
   RelengNetworkUsw1:
     region: us-west-1
     template: network.py
-    # TODO: allow parameters here, to facilitate template re-use
+    options:
+      region: usw1
 
 # vim: set ts=2 sw=2:

--- a/conftest.py
+++ b/conftest.py
@@ -1,1 +1,1 @@
-collect_ignore = ["setup.py"]
+collect_ignore = ["setup.py", "configs/cloudformation"]

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         'ssh==1.8.0',
         'wsgiref==0.1.2',
         'cfn-pyplates',
+        'IPy==0.782a',
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
This defines the releng network and is currently deployed as it appears in this patch.

There's an AWS bug around customer gateways that means this stack will "steal" the existing CGW if the IP and ASN match.  So I've faked them out for the moment.  Wen we're ready to deploy, I'll reset those to their proper values, delete the existing customer gateway, and update this stack (or re-create if there's some other bug).  Once that's done, I'll move nagios1 to the appropriate new subnet, and the delete all the old cruft.  And we'll be deploy'd!