### PR TITLE
Add "IT" SG template

### DIFF
--- a/cloudtools/scripts/aws_deploy_stack.py
+++ b/cloudtools/scripts/aws_deploy_stack.py
@@ -22,73 +22,140 @@ from cfn_pyplates.options import OptionsMapping
 log = logging.getLogger(__name__)
 
 
-def main():
-    success = deploy(sys.argv[1:])
-    if not success:
-        sys.exit(1)
+class Deployer(object):
 
+    def __init__(self, args):
+        self.connections = {}
 
-def deploy(args):
-    stacks_yml = os.path.abspath(
-        os.path.join(
-            os.path.dirname(__file__),
-            "../../configs/cloudformation/stacks.yml"))
-    parser = argparse.ArgumentParser(
-        description='deploy a cloudformation stack')
-    parser.add_argument('stack', type=str,
-                        help='CloudFormation stack to create or update')
-    parser.add_argument('--config', type=str,
-                        help='Path to stacks.yml (default is relative to this script)',
-                        default=stacks_yml)
-    parser.add_argument('--delete', action='store_true',
-                        help='Delete the stack')
-    parser.add_argument('--noop', action='store_true',
-                        help='Just parse and output the template, without updating')
-    parser.add_argument('--wait', action='store_true',
-                        help='Wait for the create or update operation to complete')
+        stacks_yml = os.path.abspath(
+            os.path.join(
+                os.path.dirname(__file__),
+                "../../configs/cloudformation/stacks.yml"))
+        parser = argparse.ArgumentParser(
+            description='deploy a cloudformation stack')
+        parser.add_argument('stack', type=str,
+                            help='CloudFormation stack to create or update')
+        parser.add_argument('--config', type=str,
+                            help='Path to stacks.yml (default is relative to this script)',
+                            default=stacks_yml)
+        parser.add_argument('--delete', action='store_true',
+                            help='Delete the stack')
+        parser.add_argument('--noop', action='store_true',
+                            help='Just parse and output the template, without updating')
+        parser.add_argument('--wait', action='store_true',
+                            help='Wait for the create or update operation to complete')
 
-    args = parser.parse_args(args)
+        args = self.args = parser.parse_args(args)
 
-    logging.basicConfig(
-        format="%(asctime)s - %(message)s", level=logging.DEBUG)
-    logging.getLogger('boto').setLevel(logging.INFO)
+        logging.basicConfig(
+            format="%(asctime)s - %(message)s", level=logging.DEBUG)
+        logging.getLogger('boto').setLevel(logging.INFO)
 
-    # load the config file
-    config = yaml.load(open(args.config))
-    if 'stacks' not in config or args.stack not in config['stacks']:
-        parser.error("Stack %r not found in %s" % (args.stack, args.config))
-    stack_config = config['stacks'][args.stack]
+        # load the config file
+        config = self.config = yaml.load(open(args.config))
+        if 'stacks' not in config or args.stack not in config['stacks']:
+            parser.error("Stack %r not found in %s" % (args.stack, args.config))
 
-    if args.delete:
-        return delete_stack(args, stack_config, args.stack)
-    else:
-        return deploy_stack(args, stack_config, args.stack)
+    def run(self):
+        if self.args.delete:
+            return self.delete_stack(self.args.stack)
+        else:
+            return self.deploy_stack(self.args.stack)
 
+    def deploy_stack(self, stack_name):
+        stack_config = self.config['stacks'][stack_name]
+        template_path = os.path.join(
+            os.path.dirname(self.args.config),
+            stack_config['template'])
+        template_body = self.load_template(stack_name, template_path)
+        if self.args.noop:
+            print template_body
+            return
 
-def deploy_stack(args, stack_config, stack_name):
-    template_path = os.path.join(os.path.dirname(args.config),
-                                 stack_config['template'])
-    template_body = load_template(args, stack_config, template_path)
-    if args.noop:
-        print template_body
-        return
+        return self.deploy_template_to_stack(stack_name, template_body)
 
-    return deploy_template(args, stack_config, template_body)
+    def deploy_template_to_stack(self, stack_name, template_body):
+        stack_config = self.config['stacks'][stack_name]
+        conn = self.conn(stack_config['region'])
 
+        try:
+            stack = conn.describe_stacks(stack_name)[0]
+            stackid = stack.stack_id
+            create = False
+        except boto.exception.BotoServerError as e:
+            if e.code != 'ValidationError':
+                raise
+            log.debug("Stack %r does not exist; creating" % stack_name)
+            create = True
 
-def load_template(args, stack_config, template_path):
-    log.debug("converting template %r to JSON", template_path)
-    # see https://github.com/seandst/cfn-pyplates/issues/27 for the
-    # solution to using these private functions
-    sys.path.insert(0, os.path.dirname(template_path))
-    options_mapping = OptionsMapping(stack_config.get('options', {}))
-    # make 'options' available for import, so that flake8 can stay
-    # happy when parsing the templates
-    cfn_pyplates.core.options = options_mapping
-    # load the template and convert the result to JSON
-    pyplate = _load_pyplate(open(template_path), options_mapping)
-    cft = _find_cloudformationtemplate(pyplate)
-    return unicode(cft)
+        if create:
+            stackid = conn.create_stack(stack_name=stack_name,
+                                        template_body=template_body)
+            event_loop = EventLoop(conn, stackid)
+        else:
+            event_loop = EventLoop(conn, stackid)
+            event_loop.consume_old_events()
+            try:
+                stackid = conn.update_stack(stack_name=stack_name,
+                                            template_body=template_body)
+            except boto.exception.BotoServerError as e:
+                # consider this particular error to indicate success
+                if e.message == 'No updates are to be performed.':
+                    log.info("Stack has not changed; treated as success")
+                    return True
+                raise
+
+        if self.args.wait:
+            return event_loop.log_events_until_done()
+        else:
+            return True
+
+    def delete_stack(self, stack_name):
+        stack_config = self.config['stacks'][stack_name]
+        conn = self.conn(stack_config['region'])
+
+        try:
+            stack = conn.describe_stacks(stack_name)[0]
+            stackid = stack.stack_id
+        except boto.exception.BotoServerError as e:
+            if e.code != 'ValidationError':
+                raise
+            log.warning("Stack %r does not exist" % stack_name)
+            return True
+
+        event_loop = EventLoop(conn, stackid)
+        event_loop.consume_old_events()
+        conn.delete_stack(stack_name)
+        if self.args.wait:
+            return event_loop.log_events_until_done(conn, stackid)
+        else:
+            return True
+
+    def load_template(self, stack_name, template_path):
+        stack_config = self.config['stacks'][stack_name]
+        log.debug("converting template %r to JSON", template_path)
+
+        # see https://github.com/seandst/cfn-pyplates/issues/27 for the
+        # solution to using these private functions
+        sys.path.insert(0, os.path.dirname(template_path))
+        options_mapping = OptionsMapping(stack_config.get('options', {}))
+
+        # make 'options' available for import, so that flake8 can stay
+        # happy when parsing the templates
+        cfn_pyplates.core.options = options_mapping
+
+        # load the template and convert the result to JSON
+        pyplate = _load_pyplate(open(template_path), options_mapping)
+        cft = _find_cloudformationtemplate(pyplate)
+        return unicode(cft)
+
+    def conn(self, region):
+        try:
+            return self.connections[region]
+        except KeyError:
+            conn = boto.cloudformation.connect_to_region(region)
+            self.connections[region] = conn
+            return conn
 
 
 class EventLoop(object):
@@ -96,101 +163,56 @@ class EventLoop(object):
     def __init__(self, conn, stackid):
         self.conn = conn
         self.stackid = stackid
-        self.seen = set()
+        self.seen_events = set()
         self.next_token = None
 
-    def iterate(self, log_events=True):
-        evts = self.conn.describe_stack_events(
-            self.stackid, next_token=self.next_token)
-        self.next_token = evts.next_token
-        # iterate until we get an empty set of events
+    def _iterate(self):
+        # iterate until we get an empty set of events or no next_token
+        new_evts = []
         while True:
+            evts = self.conn.describe_stack_events(
+                self.stackid, next_token=self.next_token)
+            self.next_token = evts.next_token
             for evt in evts:
-                if evt.event_id in self.seen:
+                if evt.event_id in self.seen_events:
                     continue
-                self.seen.add(evt.event_id)
-                if log_events:
-                    msg = "{} - {} {} -> {}".format(
-                        evt.timestamp, evt.resource_type, evt.logical_resource_id,
-                        evt.resource_status)
-                    if evt.resource_status_reason:
-                        msg += ' ({})'.format(evt.resource_status_reason)
-                    log.info(msg)
-            else:
+                self.seen_events.add(evt.event_id)
+                new_evts.append(evt)
+            if not evts or not self.next_token:
                 break
 
+        # AWS doesn't give us the events in order, so sort what we have
+        return sorted(new_evts, key=lambda e: e.timestamp)
 
-def delete_stack(args, stack_config, stack_name):
-    region = stack_config['region']
-    cf = boto.cloudformation.connect_to_region(region)
+    def consume_old_events(self):
+        self._iterate()
 
-    try:
-        stack = cf.describe_stacks(args.stack)[0]
-        stackid = stack.stack_id
-    except boto.exception.BotoServerError as e:
-        if e.code != 'ValidationError':
-            raise
-        log.warning("Stack %r does not exist" % args.stack)
-        return True
+    def log_events_until_done(self):
+        while True:
+            evts = self._iterate()
+            for evt in evts:
+                msg = "{} - {} {} -> {}".format(
+                    evt.timestamp, evt.resource_type, evt.logical_resource_id,
+                    evt.resource_status)
+                if evt.resource_status_reason:
+                    msg += ' ({})'.format(evt.resource_status_reason)
+                log.info(msg)
 
-    event_loop = EventLoop(cf, stackid)
-    # flush events before the delete
-    event_loop.iterate(log_events=False)
-    cf.delete_stack(stack_name)
-
-    return poll_stack(args, cf, event_loop, stackid)
-
-
-def deploy_template(args, stack_config, template_body):
-    region = stack_config['region']
-    cf = boto.cloudformation.connect_to_region(region)
-
-    try:
-        stack = cf.describe_stacks(args.stack)[0]
-        stackid = stack.stack_id
-        create = False
-    except boto.exception.BotoServerError as e:
-        if e.code != 'ValidationError':
-            raise
-        log.debug("Stack %r does not exist; creating" % args.stack)
-        create = True
-
-    if create:
-        stackid = cf.create_stack(stack_name=args.stack,
-                                  template_body=template_body)
-        event_loop = EventLoop(cf, stackid)
-    else:
-        # flush all of the pre-existing events before starting the
-        # update
-        event_loop = EventLoop(cf, stackid)
-        event_loop.iterate(log_events=False)
-
-        try:
-            stackid = cf.update_stack(stack_name=args.stack,
-                                      template_body=template_body)
-        except boto.exception.BotoServerError as e:
-            # consider this particular error to indicate success
-            if e.message == 'No updates are to be performed.':
-                log.info("Stack has not changed; treated as success")
+            # check the stack status
+            status = self.conn.describe_stacks(self.stackid)[0].stack_status
+            if not status.endswith('_IN_PROGRESS'):
+                log.info("Stack status: %s", status)
+                if status not in ('CREATE_COMPLETE', 'UPDATE_COMPLETE'):
+                    return False
                 return True
-            raise
 
-    return poll_stack(args, cf, event_loop, stackid)
+            time.sleep(1)
 
 
-def poll_stack(args, cf, event_loop, stackid):
-    if not args.wait:
-        return True
-    while True:
-        event_loop.iterate()
-        # if the stack is in a "terminal" condition, we're done
-        status = cf.describe_stacks(stackid)[0].stack_status
-        if not status.endswith('_IN_PROGRESS'):
-            log.info("Stack status: %s", status)
-            if status not in ('CREATE_COMPLETE', 'UPDATE_COMPLETE'):
-                return False
-            return True
-        time.sleep(2)
+def main():
+    success = Deployer(sys.argv[1:]).run()
+    if not success:
+        sys.exit(1)
 
 if __name__ == '__main__':
     main()

--- a/cloudtools/tests/test_scripts_aws_deploy_stack.py
+++ b/cloudtools/tests/test_scripts_aws_deploy_stack.py
@@ -21,27 +21,23 @@ def test_deploy_not_found(tmpdir):
             raise RuntimeError
         error.side_effect = side_effect
         assert_raises(RuntimeError, lambda:
-                      aws_deploy_stack.deploy(['--config', str(config), 'NoSuchStack']))
+                      aws_deploy_stack.Deployer(['--config', str(config), 'NoSuchStack']))
         error.assert_called_with("Stack 'NoSuchStack' not found in " + str(config))
 
 
 def test_deploy_deploy(tmpdir):
     config = tmpdir.join('stacks.yml')
     config.write(STACKS_YML)
-    with mock.patch('cloudtools.scripts.aws_deploy_stack.deploy_stack') as deploy_stack:
-        assert aws_deploy_stack.deploy(['--config', str(config), 'MyStack'])
-        deploy_stack.assert_called_with(
-            mock.ANY,
-            {'region': 'us-west-1', 'template': 'my.py'},
-            'MyStack')
+    with mock.patch('cloudtools.scripts.aws_deploy_stack.Deployer.deploy_stack') as deploy_stack:
+        d = aws_deploy_stack.Deployer(['--config', str(config), 'MyStack'])
+        d.run()
+        deploy_stack.assert_called_with('MyStack')
 
 
 def test_deploy_delete(tmpdir):
     config = tmpdir.join('stacks.yml')
     config.write(STACKS_YML)
-    with mock.patch('cloudtools.scripts.aws_deploy_stack.delete_stack') as delete_stack:
-        assert aws_deploy_stack.deploy(['--config', str(config), '--delete', 'MyStack'])
-        delete_stack.assert_called_with(
-            mock.ANY,
-            {'region': 'us-west-1', 'template': 'my.py'},
-            'MyStack')
+    with mock.patch('cloudtools.scripts.aws_deploy_stack.Deployer.delete_stack') as delete_stack:
+        d = aws_deploy_stack.Deployer(['--config', str(config), '--delete', 'MyStack'])
+        d.run()
+        delete_stack.assert_called_with('MyStack')

--- a/configs/cloudformation/README.md
+++ b/configs/cloudformation/README.md
@@ -29,10 +29,29 @@ The format of `stacks.yml` is as follows:
       * `template`: *template filename* -- the filename of the template that defines this stack
       * `options`: *option dictionary* -- an arbitrary dictionary that will be available to the template as `options`.
         This is *not* the same thing as parameters, although it is often more useful; see the pyplates documentation for details.
+        See "Inter-stack References" below, too.
+
+#### Inter-stack References
+
+Stacks often refer to resources in other stacks.
+Rather than hard-code these correspondances, the tools can look them up for you.
+Any option which has sub-keys `stack` and `resource` will be looked up before the template is generated.
+For example, to get the releng VPC's id, use
+
+```
+    options:
+        vpcid:
+            stack: RelengNetworkUsw1
+            resource: RelengVPC
+```
+
+then refer to this resource as `options['vpcid']` in the template body.
+
+Note that this system uses a "live" lookup of the resource name when the template is deployed.
+At that time, the reference is converted into a static resource id and encoded into the template.
 
 ### Future Plans
 
- * Ability to reference resource in other stacks
  * Support for parameters
  * Automatic region suffixes
 

--- a/configs/cloudformation/it.py
+++ b/configs/cloudformation/it.py
@@ -1,0 +1,35 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from cfn_pyplates.core import CloudFormationTemplate, Resource
+from cfn_pyplates.core import Properties, options
+from utils import nametag
+from utils import sgcidr
+
+cft = CloudFormationTemplate(description="IT Resources")
+
+cft.resources.add(Resource(
+    'NagiosSG', 'AWS::EC2::SecurityGroup',
+    Properties({
+        'GroupDescription': 'Nagios Servers',
+        'Tags': [nametag('nagios')],
+        'VpcId': options['vpcid'],
+        'SecurityGroupIngress': [
+            sgcidr('10.22.8.128/32', -1, -1),
+            sgcidr('10.22.20.0/25', -1, -1),
+            sgcidr('10.22.72.136/32', -1, -1),
+            sgcidr('10.22.72.155/32', -1, -1),
+            sgcidr('10.22.72.158/32', -1, -1),
+            sgcidr('10.22.72.159/32', -1, -1),
+            sgcidr('10.22.75.5/32', -1, -1),
+            sgcidr('10.22.75.6/31', -1, -1),
+            sgcidr('10.22.240.0/20', -1, -1),
+            sgcidr('10.22.74.22/32', -1, -1),
+            sgcidr('10.22.75.30/32', -1, -1),
+            sgcidr('10.22.75.36/32', 'tcp', 22),
+            sgcidr('10.22.75.136/32', 'udp', 161),
+            sgcidr('0.0.0.0/0', 'icmp', -1),
+        ],
+    }),
+))

--- a/configs/cloudformation/network.py
+++ b/configs/cloudformation/network.py
@@ -9,6 +9,7 @@ from IPy import IP
 from cfn_pyplates.core import CloudFormationTemplate, Resource
 from cfn_pyplates.core import Properties, options, DependsOn
 from cfn_pyplates.functions import ref
+from utils import nametag
 
 # Parameters
 
@@ -59,10 +60,6 @@ def subnet_cidr(suffix, length):
 def subnet_az(index):
     azs = availability_zones[options['region']]
     return azs[index % len(azs)]
-
-
-def nametag(name):
-    return {'Key': 'Name', 'Value': name}
 
 
 def resolve_host(hostname):

--- a/configs/cloudformation/stacks.yml
+++ b/configs/cloudformation/stacks.yml
@@ -6,4 +6,12 @@ stacks:
     options:
       region: usw1
 
+  ITUsw1:
+    region: us-west-1
+    template: it.py
+    options:
+      vpcid:
+        stack: RelengNetworkUsw1
+        resource: RelengVPC
+
 # vim: set ts=2 sw=2:

--- a/configs/cloudformation/utils.py
+++ b/configs/cloudformation/utils.py
@@ -1,0 +1,18 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+def nametag(name):
+    return {'Key': 'Name', 'Value': name}
+
+
+def sgcidr(cidr, proto, from_port, to_port=None):
+    if to_port is None:
+        to_port = from_port
+    return {
+        'CidrIp': cidr,
+        'IpProtocol': proto,
+        'FromPort': from_port,
+        'ToPort': to_port,
+    }


### PR DESCRIPTION
The IT template really only has to create the security group -- the instance itself isn't cloudy enough to be managed by CloudFormation.

One important bit of security group creation is referencing the VPC to which the SG belongs.  So I built out a bit of support for inter-stack references.  From what I can tell, the best practice for this is to feed such external resource IDs to CloudFormation manually via template parameters.  This is almost the same thing -- I've replaced "manually" with a handy-dandy lookup function, and replaced parameters with the much simpler pyplates feature, "options", which just substitutes the value directly into the template.

@davecurado, what do you think?  The missing piece here is that the SG is configured with a list of raw IPs, much of which will need to be repeated for lots of other security groups, so we should find a way to not be so repetitive about it.