### PR TITLE
Bug 1129958: create a means of building CentOS-6.5 servers

### DIFF
--- a/ami_configs/centos-65-x86_64-hvm-base.json
+++ b/ami_configs/centos-65-x86_64-hvm-base.json
@@ -13,7 +13,27 @@
             "int_dev_name": "/dev/xvdh",
             "mount_point": "/mnt",
             "tags": {
-                "moz-type": "bld-linux64",
+                "moz-type": "base",
+                "moz-instance-family": "c3",
+                "moz-virtualization-type": "hvm"
+            }
+        }
+    },
+    "us-west-1": {
+        "ami": "ami-f63909b3",
+        "instance_type": "c3.xlarge",
+        "arch": "x86_64",
+        "distro": "centos",
+        "virtualization_type": "hvm",
+        "target": {
+            "size": 35,
+            "fs_type": "ext4",
+            "e2_label": "root_dev",
+            "aws_dev_name": "/dev/sdh",
+            "int_dev_name": "/dev/xvdh",
+            "mount_point": "/mnt",
+            "tags": {
+                "moz-type": "base",
                 "moz-instance-family": "c3",
                 "moz-virtualization-type": "hvm"
             }
@@ -33,7 +53,7 @@
             "int_dev_name": "/dev/xvdh",
             "mount_point": "/mnt",
             "tags": {
-                "moz-type": "bld-linux64",
+                "moz-type": "base",
                 "moz-instance-family": "c3",
                 "moz-virtualization-type": "hvm"
             }

--- a/ami_configs/centos-65-x86_64-hvm-base/additional_packages
+++ b/ami_configs/centos-65-x86_64-hvm-base/additional_packages
@@ -2,3 +2,5 @@ dhclient
 openssh-server
 kernel
 grub
+lvm2
+yum

--- a/ami_configs/centos-65-x86_64-hvm-base/groupinstall
+++ b/ami_configs/centos-65-x86_64-hvm-base/groupinstall
@@ -1,1 +1,2 @@
-Base
+# See https://bugzilla.mozilla.org/show_bug.cgi?id=1129958
+Core

--- a/cloudtools/aws/instance.py
+++ b/cloudtools/aws/instance.py
@@ -123,7 +123,7 @@ def assimilate_instance(instance, config, ssh_key, instance_data, deploypass,
             '{}/etc/apt/sources.list'.format(chroot))
         run_chroot("apt-get update")
         run_chroot("apt-get install -y --allow-unauthenticated "
-                   "puppet cloud-init")
+                   "puppet cloud-init wget")
         run_chroot("apt-get clean")
     else:
         # Set up yum repos
@@ -131,7 +131,7 @@ def assimilate_instance(instance, config, ssh_key, instance_data, deploypass,
         put('%s/releng-public.repo' % AMI_CONFIGS_DIR,
             '{}/etc/yum.repos.d/releng-public.repo'.format(chroot))
         run_chroot('yum clean all')
-        run_chroot('yum install -q -y puppet cloud-init')
+        run_chroot('yum install -q -y puppet cloud-init wget')
 
     run_chroot("wget -O /root/puppetize.sh "
                "https://hg.mozilla.org/build/puppet/"

--- a/cloudtools/scripts/aws_create_ami.py
+++ b/cloudtools/scripts/aws_create_ami.py
@@ -158,7 +158,7 @@ def create_ami(host_instance, args, config, instance_config, ssh_key,
 
     # Step 0: install required packages
     if config.get('distro') == "centos":
-        run('which MAKEDEV >/dev/null || yum install -y MAKEDEV')
+        run('which MAKEDEV >/dev/null || yum -d 1 install -y MAKEDEV')
 
     # Step 1: prepare target FS
     run('mkdir -p %s' % mount_point)
@@ -213,7 +213,7 @@ def create_ami(host_instance, args, config, instance_config, ssh_key,
             put('etc/yum-local.cfg', '%s/etc/yum-local.cfg' % mount_point)
             put('groupinstall', '/tmp/groupinstall')
             put('additional_packages', '/tmp/additional_packages')
-        yum = 'yum -c {0}/etc/yum-local.cfg -y --installroot={0} '.format(
+        yum = 'yum -d 1 -c {0}/etc/yum-local.cfg -y --installroot={0} '.format(
             mount_point)
         run('%s groupinstall "`cat /tmp/groupinstall`"' % yum)
         run('%s install `cat /tmp/additional_packages`' % yum)
@@ -273,7 +273,7 @@ def create_ami(host_instance, args, config, instance_config, ssh_key,
             grub_install_patch = os.path.join(config_dir, "grub-install.diff")
             if os.path.exists(grub_install_patch):
                 put(grub_install_patch, "/tmp/grub-install.diff")
-                run('which patch >/dev/null || yum install -y patch')
+                run('which patch >/dev/null || yum -d 1 install -y patch')
                 run('patch -p0 -i /tmp/grub-install.diff /sbin/grub-install')
             run("grub-install --root-directory=%s --no-floppy %s" %
                 (mount_point, grub_dev))
@@ -322,7 +322,7 @@ def create_ami(host_instance, args, config, instance_config, ssh_key,
     if config.get("root_device_type") == "instance-store" \
             and config.get("distro") == "centos":
         # create bundle
-        run("yum install -y ruby "
+        run("yum -d 1 install -y ruby "
             "http://s3.amazonaws.com/ec2-downloads/ec2-ami-tools.noarch.rpm")
         bundle_location = "{b}/{d}/{t}/{n}".format(
             b=config["bucket"], d=config["bucket_dir"],

--- a/cloudtools/scripts/aws_create_ami.py
+++ b/cloudtools/scripts/aws_create_ami.py
@@ -215,7 +215,10 @@ def create_ami(host_instance, args, config, instance_config, ssh_key,
             put('additional_packages', '/tmp/additional_packages')
         yum = 'yum -d 1 -c {0}/etc/yum-local.cfg -y --installroot={0} '.format(
             mount_point)
+        # groupinstall emulates the %packages section of the kickstart config
         run('%s groupinstall "`cat /tmp/groupinstall`"' % yum)
+        # and this attempts to emulate the additional packages that Anaconda installs
+        # as it needs them.
         run('%s install `cat /tmp/additional_packages`' % yum)
         run('%s clean packages' % yum)
         # Rebuild RPM DB for cases when versions mismatch

--- a/configs/server-linux64
+++ b/configs/server-linux64
@@ -1,0 +1,105 @@
+{
+    "hostname": "generic-server%02d",
+    "us-east-1": {
+        "type": "server-linux64",
+        "domain": "srv.releng.use1.mozilla.com",
+        "ami": "ami-18abe670",
+        "subnet_ids": ["subnet-173ff076", "subnet-1b20ef7a", "subnet-35a9835e", "subnet-0aa98361", "subnet-30a9835b", "subnet-33a98358", "subnet-8f21eeee", "subnet-8c20efed"],
+        "security_group_ids": ["sg-31e8185e"],
+        "instance_type": "c3.xlarge",
+        "disable_api_termination": true,
+        "ssh_key": "aws-releng",
+        "use_public_ip": true,
+        "device_map": {
+            "/dev/xvda": {
+                "delete_on_termination": true,
+                "skip_resize": true,
+                "volume_type": "gp2",
+                "instance_dev": "/dev/xvda1"
+            },  
+            "/dev/sdb": {
+                "ephemeral_name": "ephemeral0",
+                "instance_dev": "/dev/xvdb",
+                "skip_resize": true,
+                "delete_on_termination": false
+            },
+            "/dev/sdc": {
+                "ephemeral_name": "ephemeral1",
+                "instance_dev": "/dev/xvdc",
+                "skip_resize": true,
+                "delete_on_termination": false
+            }
+        },
+        "tags": {
+            "moz-type": "server-linux64"
+        }
+    },
+    "us-west-1": {
+        "type": "server-linux64",
+        "domain": "srv.releng.usw2.mozilla.com",
+        "ami": "ami-c86d768d",
+        "subnet_ids": ["subnet-2f465b69", "subnet-39f02d5c", "subnet-30f02d55", "subnet-2a465b6c"],
+        "security_group_ids": ["sg-932e33ff"],
+        "instance_type": "c3.xlarge",
+        "disable_api_termination": true,
+        "ssh_key": "aws-releng",
+        "use_public_ip": true,
+        "device_map": {
+            "/dev/xvda": {
+                "delete_on_termination": true,
+                "skip_resize": true,
+                "volume_type": "gp2",
+                "instance_dev": "/dev/xvda1"
+            },
+            "/dev/sdb": {
+                "ephemeral_name": "ephemeral0",
+                "instance_dev": "/dev/xvdb",
+                "skip_resize": true,
+                "delete_on_termination": false
+            },
+            "/dev/sdc": {
+                "ephemeral_name": "ephemeral1",
+                "instance_dev": "/dev/xvdc",
+                "skip_resize": true,
+                "delete_on_termination": false
+            }
+        },
+        "tags": {
+            "moz-type": "server-linux64"
+        }
+    },
+    "us-west-2": {
+        "type": "server-linux64",
+        "domain": "srv.releng.usw2.mozilla.com",
+        "ami": "ami-51f9a261",
+        "subnet_ids": ["subnet-b948dad0", "subnet-ba48dad3", "subnet-ed464a99", "subnet-bf48dad6"],
+        "security_group_ids": ["sg-932e33ff"],
+        "instance_type": "c3.xlarge",
+        "disable_api_termination": true,
+        "ssh_key": "aws-releng",
+        "use_public_ip": true,
+        "device_map": {
+            "/dev/xvda": {
+                "delete_on_termination": true,
+                "skip_resize": true,
+                "volume_type": "gp2",
+                "instance_dev": "/dev/xvda1"
+            },
+            "/dev/sdb": {
+                "ephemeral_name": "ephemeral0",
+                "instance_dev": "/dev/xvdb",
+                "skip_resize": true,
+                "delete_on_termination": false
+            },
+            "/dev/sdc": {
+                "ephemeral_name": "ephemeral1",
+                "instance_dev": "/dev/xvdc",
+                "skip_resize": true,
+                "delete_on_termination": false
+            }
+        },
+        "tags": {
+            "moz-type": "server-linux64"
+        }
+    }
+}

--- a/configs/server-linux64.cloud-init
+++ b/configs/server-linux64.cloud-init
@@ -1,0 +1,11 @@
+#cloud-config
+
+fqdn: {fqdn}
+hostname: {fqdn}
+package_update: false
+resize_rootfs: true
+manage_etc_hosts: true
+disable_root: false
+ssh_pwauth: true
+moz_instance_type: {moz_instance_type}
+mounts: false

--- a/instance_data/us-east-1.instance_data_server_linux64.json
+++ b/instance_data/us-east-1.instance_data_server_linux64.json
@@ -1,0 +1,3 @@
+{
+  "puppet_masters": ["releng-puppet1.srv.releng.scl3.mozilla.com", "releng-puppet2.srv.releng.scl3.mozilla.com"]
+}

--- a/instance_data/us-west-1.instance_data_server_linux64.json
+++ b/instance_data/us-west-1.instance_data_server_linux64.json
@@ -1,0 +1,3 @@
+{
+  "puppet_masters": ["releng-puppet1.srv.releng.scl3.mozilla.com", "releng-puppet2.srv.releng.scl3.mozilla.com"]
+}

--- a/instance_data/us-west-2.instance_data_server_linux64.json
+++ b/instance_data/us-west-2.instance_data_server_linux64.json
@@ -1,0 +1,3 @@
+{
+  "puppet_masters": ["releng-puppet1.srv.releng.scl3.mozilla.com", "releng-puppet2.srv.releng.scl3.mozilla.com"]
+}


### PR DESCRIPTION
I suspect that this will work for buildbot masters, too, but that's out of scope here.  This did successfully rebuild rpmpackager1.

It's well broken out into commits to describe each step.