### PR TITLE
switch bld-linux64 and try-linux64 to use the new Core-only base AMI

### DIFF
--- a/configs/bld-linux64
+++ b/configs/bld-linux64
@@ -3,7 +3,7 @@
     "us-east-1": {
         "type": "bld-linux64",
         "domain": "build.releng.use1.mozilla.com",
-        "ami": "ami-6c92d204",
+        "ami": "ami-18abe670",
         "subnet_ids": ["subnet-2ba98340", "subnet-2da98346", "subnet-22a98349", "subnet-0822004e", "subnet-2da98346", "subnet-5bc7c62f", "subnet-7091d358"],
         "security_group_ids": ["sg-e758e982"],
         "instance_type": "c3.xlarge",
@@ -38,7 +38,7 @@
     "us-west-2": {
         "type": "bld-linux64",
         "domain": "build.releng.usw2.mozilla.com",
-        "ami": "ami-8f114abf",
+        "ami": "ami-51f9a261",
         "subnet_ids": ["subnet-d748dabe", "subnet-a848dac1", "subnet-ad48dac4", "subnet-c74f48b3"],
         "security_group_ids": ["sg-f5ca0690"],
         "instance_type": "c3.xlarge",

--- a/configs/try-linux64
+++ b/configs/try-linux64
@@ -3,7 +3,7 @@
     "us-east-1": {
         "type": "try-linux64",
         "domain": "try.releng.use1.mozilla.com",
-        "ami": "ami-6c92d204",
+        "ami": "ami-18abe670",
         "subnet_ids": ["subnet-27a9834c", "subnet-39a98352", "subnet-3ea98355", "subnet-93b285e7", "subnet-e5bacacd", "subnet-cd83d28b"],
         "security_group_ids": ["sg-718b1214"],
         "instance_type": "c3.xlarge",
@@ -38,7 +38,7 @@
     "us-west-2": {
         "type": "try-linux64",
         "domain": "try.releng.usw2.mozilla.com",
-        "ami": "ami-8f114abf",
+        "ami": "ami-51f9a261",
         "subnet_ids": ["subnet-ae48dac7", "subnet-a348daca", "subnet-a448dacd", "subnet-72b68206"],
         "security_group_ids": ["sg-3aaa095f"],
         "instance_type": "c3.xlarge",


### PR DESCRIPTION
Currently running as the try spot AMI in us-east-1:
```
2015-02-06 09:42:31,391 - INFO - ID: ami-78612e10, name: spot-try-linux64-2015-02-06-17-15
```
so assuming that doesn't melt down, this should be good to go.