### PR TITLE
Bug 1130548: update the base AMIs to work for both servers and builders

### DIFF
--- a/ami_configs/centos-65-x86_64-hvm-base/additional_packages
+++ b/ami_configs/centos-65-x86_64-hvm-base/additional_packages
@@ -1,6 +1,0 @@
-dhclient
-openssh-server
-kernel
-grub
-lvm2
-yum

--- a/ami_configs/centos-65-x86_64-hvm-base/groupinstall
+++ b/ami_configs/centos-65-x86_64-hvm-base/groupinstall
@@ -1,2 +1,0 @@
-# See https://bugzilla.mozilla.org/show_bug.cgi?id=1129958
-Core

--- a/cloudtools/scripts/aws_create_ami.py
+++ b/cloudtools/scripts/aws_create_ami.py
@@ -211,15 +211,11 @@ def create_ami(host_instance, args, config, instance_config, ssh_key,
     else:
         with lcd(config_dir):
             put('etc/yum-local.cfg', '%s/etc/yum-local.cfg' % mount_point)
-            put('groupinstall', '/tmp/groupinstall')
-            put('additional_packages', '/tmp/additional_packages')
         yum = 'yum -d 1 -c {0}/etc/yum-local.cfg -y --installroot={0} '.format(
             mount_point)
-        # groupinstall emulates the %packages section of the kickstart config
-        run('%s groupinstall "`cat /tmp/groupinstall`"' % yum)
-        # and this attempts to emulate the additional packages that Anaconda installs
-        # as it needs them.
-        run('%s install `cat /tmp/additional_packages`' % yum)
+        # this groupinstall emulates the %packages section of the kickstart
+        # config, which defaults to Core and Base.
+        run('%s groupinstall Core Base' % yum)
         run('%s clean packages' % yum)
         # Rebuild RPM DB for cases when versions mismatch
         run('chroot %s rpmdb --rebuilddb || :' % mount_point)

--- a/configs/bld-linux64
+++ b/configs/bld-linux64
@@ -3,7 +3,7 @@
     "us-east-1": {
         "type": "bld-linux64",
         "domain": "build.releng.use1.mozilla.com",
-        "ami": "ami-6c92d204",
+        "ami": "ami-58246f30",
         "subnet_ids": ["subnet-2ba98340", "subnet-2da98346", "subnet-22a98349", "subnet-0822004e", "subnet-2da98346", "subnet-5bc7c62f", "subnet-7091d358"],
         "security_group_ids": ["sg-e758e982"],
         "instance_type": "c3.xlarge",
@@ -38,7 +38,7 @@
     "us-west-2": {
         "type": "bld-linux64",
         "domain": "build.releng.usw2.mozilla.com",
-        "ami": "ami-8f114abf",
+        "ami": "ami-eb89acdb",
         "subnet_ids": ["subnet-d748dabe", "subnet-a848dac1", "subnet-ad48dac4", "subnet-c74f48b3"],
         "security_group_ids": ["sg-f5ca0690"],
         "instance_type": "c3.xlarge",

--- a/configs/buildbot-master
+++ b/configs/buildbot-master
@@ -3,7 +3,7 @@
     "us-east-1": {
         "type": "buildbot-master",
         "domain": "bb.releng.use1.mozilla.com",
-        "ami": "ami-18abe670",
+        "ami": "ami-58246f30",
         "subnet_ids": ["subnet-5bea1b2c", "subnet-8992a1a1", "subnet-9be0f3dd"],
         "security_group_ids": ["sg-31e8185e"],
         "instance_type": "m3.medium",
@@ -32,7 +32,7 @@
     "us-west-1": {
         "type": "buildbot-master",
         "domain": "bb.releng.use1.mozilla.com",
-        "ami": "ami-c86d768d",
+        "ami": "ami-18a7bc5d",
         "subnet_ids": ["subnet-37465b71", "subnet-33f02d56", "subnet-31f02d54", "subnet-2e465b68"],
         "security_group_ids": ["sg-31e8185e"],
         "instance_type": "m3.medium",

--- a/configs/try-linux64
+++ b/configs/try-linux64
@@ -3,7 +3,7 @@
     "us-east-1": {
         "type": "try-linux64",
         "domain": "try.releng.use1.mozilla.com",
-        "ami": "ami-6c92d204",
+        "ami": "ami-58246f30",
         "subnet_ids": ["subnet-27a9834c", "subnet-39a98352", "subnet-3ea98355", "subnet-93b285e7", "subnet-e5bacacd", "subnet-cd83d28b"],
         "security_group_ids": ["sg-718b1214"],
         "instance_type": "c3.xlarge",
@@ -38,7 +38,7 @@
     "us-west-2": {
         "type": "try-linux64",
         "domain": "try.releng.usw2.mozilla.com",
-        "ami": "ami-8f114abf",
+        "ami": "ami-eb89acdb",
         "subnet_ids": ["subnet-ae48dac7", "subnet-a348daca", "subnet-a448dacd", "subnet-72b68206"],
         "security_group_ids": ["sg-3aaa095f"],
         "instance_type": "c3.xlarge",


### PR DESCRIPTION
I'm in the process of testing this for buildbot masters, and will create a canary for builders tomorrow before landing it.