### PR TITLE
Bug 1124313 - centralized logging

### DIFF
--- a/cloudtools/aws/__init__.py
+++ b/cloudtools/aws/__init__.py
@@ -276,3 +276,12 @@ def get_impaired_instance_ids(region):
     impaired = conn.get_all_instance_status(
         filters={'instance-status.status': 'impaired'})
     return [i.id for i in impaired]
+
+
+def get_moz_region(region):
+    mapping = {
+        "us-east-1": "use1",
+        "us-west-1": "usw1",
+        "us-west-2": "usw2",
+    }
+    return mapping.get(region)

--- a/cloudtools/aws/__init__.py
+++ b/cloudtools/aws/__init__.py
@@ -278,7 +278,8 @@ def get_impaired_instance_ids(region):
     return [i.id for i in impaired]
 
 
-def get_moz_region(region):
+def get_region_dns_atom(region):
+    """Maps AWS regions to region names used by Mozilla in DNS names"""
     mapping = {
         "us-east-1": "use1",
         "us-west-1": "usw1",

--- a/cloudtools/aws/instance.py
+++ b/cloudtools/aws/instance.py
@@ -12,7 +12,7 @@ from fabric.context_managers import cd
 from ..fabric import setup_fabric_env
 from ..dns import get_ip
 from . import wait_for_status, AMI_CONFIGS_DIR, get_aws_connection, \
-    get_user_data_tmpl
+    get_user_data_tmpl, get_moz_region
 from .vpc import get_subnet_id, ip_available, get_vpc
 from boto.exception import BotoServerError, EC2ResponseError
 
@@ -287,11 +287,13 @@ def create_block_device_mapping(ami, device_map):
     return bdm
 
 
-def user_data_from_template(moz_instance_type, fqdn):
+def user_data_from_template(moz_instance_type, fqdn, region):
     user_data = get_user_data_tmpl(moz_instance_type)
     if user_data:
-        user_data = user_data.format(fqdn=fqdn,
-                                     moz_instance_type=moz_instance_type)
+        user_data = user_data.format(
+            fqdn=fqdn,
+            moz_region=get_moz_region(region),
+            moz_instance_type=moz_instance_type)
 
     return user_data
 

--- a/cloudtools/aws/instance.py
+++ b/cloudtools/aws/instance.py
@@ -12,7 +12,7 @@ from fabric.context_managers import cd
 from ..fabric import setup_fabric_env
 from ..dns import get_ip
 from . import wait_for_status, AMI_CONFIGS_DIR, get_aws_connection, \
-    get_user_data_tmpl, get_moz_region
+    get_user_data_tmpl, get_region_dns_atom
 from .vpc import get_subnet_id, ip_available, get_vpc
 from boto.exception import BotoServerError, EC2ResponseError
 
@@ -292,7 +292,7 @@ def user_data_from_template(moz_instance_type, fqdn, region):
     if user_data:
         user_data = user_data.format(
             fqdn=fqdn,
-            moz_region=get_moz_region(region),
+            region_dns_atom=get_region_dns_atom(region),
             moz_instance_type=moz_instance_type)
 
     return user_data

--- a/cloudtools/scripts/aws_create_instance.py
+++ b/cloudtools/scripts/aws_create_instance.py
@@ -12,7 +12,7 @@ import logging
 from boto.ec2.blockdevicemapping import BlockDeviceMapping, BlockDeviceType
 
 from cloudtools.aws import get_aws_connection, get_vpc, \
-    name_available, wait_for_status, get_user_data_tmpl, get_moz_region
+    name_available, wait_for_status, get_user_data_tmpl, get_region_dns_atom
 from cloudtools.dns import get_ip, get_ptr
 from cloudtools.aws.instance import assimilate_instance, \
     make_instance_interfaces
@@ -115,7 +115,7 @@ def create_instance(name, config, region, key_name, ssh_key, instance_data,
                     dns_search_domain=config.get('dns_search_domain'),
                     password=deploypass,
                     moz_instance_type=config['type'],
-                    moz_region=get_moz_region(region),
+                    region_dns_atom=get_region_dns_atom(region),
                 )
 
             reservation = conn.run_instances(

--- a/cloudtools/scripts/aws_create_instance.py
+++ b/cloudtools/scripts/aws_create_instance.py
@@ -12,7 +12,7 @@ import logging
 from boto.ec2.blockdevicemapping import BlockDeviceMapping, BlockDeviceType
 
 from cloudtools.aws import get_aws_connection, get_vpc, \
-    name_available, wait_for_status, get_user_data_tmpl
+    name_available, wait_for_status, get_user_data_tmpl, get_moz_region
 from cloudtools.dns import get_ip, get_ptr
 from cloudtools.aws.instance import assimilate_instance, \
     make_instance_interfaces
@@ -115,6 +115,7 @@ def create_instance(name, config, region, key_name, ssh_key, instance_data,
                     dns_search_domain=config.get('dns_search_domain'),
                     password=deploypass,
                     moz_instance_type=config['type'],
+                    moz_region=get_moz_region(region),
                 )
 
             reservation = conn.run_instances(

--- a/cloudtools/scripts/aws_watch_pending.py
+++ b/cloudtools/scripts/aws_watch_pending.py
@@ -220,7 +220,7 @@ def do_request_instance(region, moz_instance_type, price, ami, instance_config,
         groups=instance_config[region].get("security_group_ids"))
     nc = NetworkInterfaceCollection(spec)
 
-    user_data = user_data_from_template(moz_instance_type, fqdn)
+    user_data = user_data_from_template(moz_instance_type, fqdn, region)
     bdm = create_block_device_mapping(
         ami, instance_config[region]['device_map'])
     if is_spot:

--- a/configs/bld-linux64.cloud-init
+++ b/configs/bld-linux64.cloud-init
@@ -11,4 +11,4 @@ moz_instance_type: {moz_instance_type}
 mounts: false
 rsyslog:
  - filename: log_aggregator_client.conf
-   content: "*.* @@log-aggregator.srv.releng.{moz_region}.mozilla.com:1514"
+   content: "*.* @@log-aggregator.srv.releng.{region_dns_atom}.mozilla.com:1514"

--- a/configs/bld-linux64.cloud-init
+++ b/configs/bld-linux64.cloud-init
@@ -9,3 +9,6 @@ disable_root: false
 ssh_pwauth: true
 moz_instance_type: {moz_instance_type}
 mounts: false
+rsyslog:
+ - filename: log_aggregator_client.conf
+   content: "*.* @@log-aggregator.srv.releng.{moz_region}.mozilla.com:1514"

--- a/configs/buildbot-master.cloud-init
+++ b/configs/buildbot-master.cloud-init
@@ -16,4 +16,4 @@ bootcmd:
  - swapon /dev/$(curl http://169.254.169.254/latest/meta-data/block-device-mapping/ephemeral0)
 rsyslog:
  - filename: log_aggregator_client.conf
-   content: "*.* @@log-aggregator.srv.releng.{moz_region}.mozilla.com:1514"
+   content: "*.* @@log-aggregator.srv.releng.{region_dns_atom}.mozilla.com:1514"

--- a/configs/buildbot-master.cloud-init
+++ b/configs/buildbot-master.cloud-init
@@ -14,3 +14,6 @@ mounts:
 bootcmd:
  - mkswap /dev/$(curl http://169.254.169.254/latest/meta-data/block-device-mapping/ephemeral0)
  - swapon /dev/$(curl http://169.254.169.254/latest/meta-data/block-device-mapping/ephemeral0)
+rsyslog:
+ - filename: log_aggregator_client.conf
+   content: "*.* @@log-aggregator.srv.releng.{moz_region}.mozilla.com:1514"

--- a/configs/server-linux64.cloud-init
+++ b/configs/server-linux64.cloud-init
@@ -13,3 +13,6 @@ mounts:
 bootcmd:
  - mkswap /dev/$(curl http://169.254.169.254/latest/meta-data/block-device-mapping/ephemeral0)
  - swapon /dev/$(curl http://169.254.169.254/latest/meta-data/block-device-mapping/ephemeral0)
+rsyslog:
+ - filename: log_aggregator_client.conf
+   content: "*.* @@log-aggregator.srv.releng.{moz_region}.mozilla.com:1514"

--- a/configs/server-linux64.cloud-init
+++ b/configs/server-linux64.cloud-init
@@ -15,4 +15,4 @@ bootcmd:
  - swapon /dev/$(curl http://169.254.169.254/latest/meta-data/block-device-mapping/ephemeral0)
 rsyslog:
  - filename: log_aggregator_client.conf
-   content: "*.* @@log-aggregator.srv.releng.{moz_region}.mozilla.com:1514"
+   content: "*.* @@log-aggregator.srv.releng.{region_dns_atom}.mozilla.com:1514"

--- a/configs/tst-linux64.cloud-init
+++ b/configs/tst-linux64.cloud-init
@@ -10,4 +10,4 @@ ssh_pwauth: true
 moz_instance_type: {moz_instance_type}
 rsyslog:
  - filename: log_aggregator_client.conf
-   content: "*.* @@log-aggregator.srv.releng.{moz_region}.mozilla.com:1514"
+   content: "*.* @@log-aggregator.srv.releng.{region_dns_atom}.mozilla.com:1514"

--- a/configs/tst-linux64.cloud-init
+++ b/configs/tst-linux64.cloud-init
@@ -8,3 +8,6 @@ manage_etc_hosts: true
 disable_root: false
 ssh_pwauth: true
 moz_instance_type: {moz_instance_type}
+rsyslog:
+ - filename: log_aggregator_client.conf
+   content: "*.* @@log-aggregator.srv.releng.{moz_region}.mozilla.com:1514"


### PR DESCRIPTION
We need to overwrite Puppet generated rsyslog configs based on region. Golden AMIs are copied across regions (to keep them identical), so they have the same syslog server set.

This patch adds rsyslog section into cloud-init files. Also need to convert AWS region names to Moz region names. :)