### PR TITLE
Update regex to not match the random-word on 'debug' which makes the neg...

### DIFF
--- a/configs/watch_pending.cfg
+++ b/configs/watch_pending.cfg
@@ -5,8 +5,8 @@
         "us-west-1": 0
     },
     "buildermap": {
-        "Android.* (?!try|Tegra|Panda|Emulator)\\S+ (build|non-unified)": "bld-linux64",
-        "Android.* (?!Tegra|Panda|Emulator)try build": "try-linux64",
+        "Android.* (?!try|Tegra|Panda|Emulator|debug)\\S+ (?:debug )?(build|non-unified)": "bld-linux64",
+        "Android.* (?!Tegra|Panda|Emulator)try (?:debug )?build": "try-linux64",
         "^(TB )?Linux (Code Coverage |Mulet )?(?!try)\\S+ (pgo-|leak test |Code Coverage |Mulet )?(spidermonkey.* )?build": "bld-linux64",
         "^(TB )?Linux x86-64 (Code Coverage |Mulet )?(?!try)\\S+ (pgo-|leak test |asan |debug asan |debug static analysis )?(spidermonkey.* )?(build|non-unified)": "bld-linux64",
         "^(TB )?(Android|Linux).* (nightly|non-profiling)": "bld-linux64",


### PR DESCRIPTION
...ative lookahead for 'try' pass

fixes
FAIL-MISMATCH        try-linux64      bld-linux64     Android armv7 API 11+ try debug build
FAIL-MISMATCH        try-linux64      bld-linux64     Android armv7 API 9 try debug build