### PR TITLE
Negative Lookahead for b2g_emulator_vm_large to make sure we spin emulat...

### DIFF
--- a/configs/watch_pending.cfg
+++ b/configs/watch_pending.cfg
@@ -23,7 +23,7 @@
         "^Ubuntu (Code Coverage )?VM 12.04 x64.*": "tst-linux64",
         "^Ubuntu Mulet VM 12.04 x64.*": "tst-linux64",
         "^Ubuntu ASAN VM 12.04 x64.*": "tst-linux64",
-        "^b2g_(emulator|ubuntu64)(-jb|-kk)?_vm": "tst-linux64",
+        "^b2g_(emulator|ubuntu64)(-jb|-kk)?_vm(?!_large)": "tst-linux64",
         "^Android 2.3( Armv6)? Emulator(?:(?!plain-reftest|crashtest|jsreftest).)*$": "tst-linux64",
         "^Android 2.3( Armv6)? Emulator.*(?:plain-reftest|crashtest|jsreftest)": "tst-emulator64",
         "^Android armv7 API 9.*test (?:(?!plain-reftest|crashtest|jsreftest).)*$": "tst-linux64",


### PR DESCRIPTION
...or and not less-powerful instances

Solves
FAIL-MULTI-MATCH     tst-emulator64   tst-linux64,tst-emulator64 b2g_emulator_vm_large cedar opt test mochitest-media