### PR TITLE
bug 1166448 - support golden ami creation for win 2008 bld/try

### DIFF
--- a/cloudtools/aws/ami.py
+++ b/cloudtools/aws/ami.py
@@ -12,28 +12,29 @@ log = logging.getLogger(__name__)
 
 
 def ami_cleanup(mount_point, distro, remove_extra=None):
-    remove_extra = remove_extra or []
-    remove = [
-        "root/*.sh",
-        "root/*.log",
-        "root/userdata",
-        "var/lib/puppet",
-        "etc/init.d/puppet"
-    ]
-    with cd(mount_point):
-        for e in remove + remove_extra:
-            run('rm -rf %s' % (e,))
-        run("sed -i -e 's/127.0.0.1.*/127.0.0.1 localhost/g' etc/hosts")
-        put("%s/fake_puppet.sh" % AMI_CONFIGS_DIR,
-            "usr/sbin/fake_puppet.sh", mirror_local_mode=True)
-        # replace puppet init with our script
-        if distro == "ubuntu":
-            put("%s/fake_puppet.conf" % AMI_CONFIGS_DIR,
-                "etc/init/puppet.conf", mirror_local_mode=True)
-            run("echo localhost > etc/hostname")
-        else:
-            run("ln -sf /usr/sbin/fake_puppet.sh etc/init.d/puppet")
-            run('echo "NETWORKING=yes" > etc/sysconfig/network')
+    if not distro.startswith('win'):
+        remove_extra = remove_extra or []
+        remove = [
+            "root/*.sh",
+            "root/*.log",
+            "root/userdata",
+            "var/lib/puppet",
+            "etc/init.d/puppet"
+        ]
+        with cd(mount_point):
+            for e in remove + remove_extra:
+                run('rm -rf %s' % (e,))
+            run("sed -i -e 's/127.0.0.1.*/127.0.0.1 localhost/g' etc/hosts")
+            put("%s/fake_puppet.sh" % AMI_CONFIGS_DIR,
+                "usr/sbin/fake_puppet.sh", mirror_local_mode=True)
+            # replace puppet init with our script
+            if distro == "ubuntu":
+                put("%s/fake_puppet.conf" % AMI_CONFIGS_DIR,
+                    "etc/init/puppet.conf", mirror_local_mode=True)
+                run("echo localhost > etc/hostname")
+            else:
+                run("ln -sf /usr/sbin/fake_puppet.sh etc/init.d/puppet")
+                run('echo "NETWORKING=yes" > etc/sysconfig/network')
 
 
 def volume_to_ami(volume, ami_name, arch, virtualization_type,

--- a/configs/b-2008
+++ b/configs/b-2008
@@ -1,0 +1,60 @@
+{
+    "hostname": "b-2008-ec2-%03d",
+    "us-east-1": {
+        "type": "b-2008",
+        "domain": "build.releng.use1.mozilla.com",
+        "ami": "ami-1d47b276",
+        "subnet_ids": ["subnet-2ba98340", "subnet-2da98346", "subnet-22a98349", "subnet-0822004e", "subnet-2da98346", "subnet-5bc7c62f", "subnet-7091d358"],
+        "security_group_ids": [
+            "sg-18a07677",
+            "sg-e758e982"
+        ],
+        "instance_type": "r3.xlarge",
+        "distro": "win2008",
+        "ssh_key": "aws-releng",
+        "user_data_file": "../../configs/b-2008.cmd.user_data",
+        "use_public_ip": true,
+        "instance_profile_name": "b-2008",
+        "device_map": {
+            "/dev/sda1": {
+                "delete_on_termination": true,
+                "skip_resize": true,
+                "volume_type": "gp2",
+                "size": 80,
+                "instance_dev": "C:"
+            }
+        },
+        "tags": {
+            "moz-type": "b-2008"
+        }
+    },
+    "us-west-2": {
+        "type": "b-2008",
+        "domain": "build.releng.usw2.mozilla.com",
+        "ami": "ami-9b8bb3ab",
+        "subnet_ids": ["subnet-d748dabe", "subnet-a848dac1", "subnet-ad48dac4", "subnet-c74f48b3"],
+        "security_group_ids": [
+            "sg-f5ca0690",
+            "sg-84beade6"
+        ],
+        "instance_type": "r3.xlarge",
+        "distro": "win2008",
+        "ssh_key": "aws-releng",
+        "user_data_file": "../../configs/b-2008.cmd.user_data",
+        "use_public_ip": true,
+        "instance_profile_name": "b-2008",
+        "device_map": {
+            "/dev/sda1": {
+                "delete_on_termination": true,
+                "skip_resize": true,
+                "volume_type": "gp2",
+                "size": 80,
+                "instance_dev": "C:"
+            }
+        },
+        "tags": {
+            "moz-type": "b-2008"
+        }
+    }
+
+}

--- a/configs/b-2008.cmd.user_data
+++ b/configs/b-2008.cmd.user_data
@@ -1,0 +1,72 @@
+<script>
+set FACTER_domain=build.releng.use1.mozilla.com
+
+set FACTER_hostname=b-2008-ec2-golden
+
+set FACTER_fqdn=b-2008-ec2-golden.build.releng.use1.mozilla.com
+
+set COMPUTERNAME=b-2008-ec2-golden
+
+setx FACTER_domain build.releng.use1.mozilla.com
+
+setx FACTER_hostname b-2008-ec2-golden
+
+setx FACTER_fqdn b-2008-ec2-golden.build.releng.use1.mozilla.com
+
+setx COMPUTERNAME b-2008-ec2-golden
+
+
+
+sc delete puppet 
+
+cscript.exe C:\ProgramData\Puppetlabs\puppet\var\puppettize_TEMP.vbs" 
+
+cd "C:\Program Files (x86)\Puppet Labs\Puppet\bin" 
+
+rem Get start time: 
+
+for /F "tokens=1-4 delims=:.," %%a in ("%time%") do ( 
+
+   set /A "start=(((%%a*60)+1%%b %% 100)*60+1%%c %% 100)*100+1%%d %% 100
+)
+ 
+Set /A elapsed=0 
+ 
+:RUN 
+ 
+IF %elapsed% lss 600 GOTO :COMMAND ( 
+
+IF %elapsed% gtr 600 GOTO :WAIT ( 
+ 
+:WAIT 
+
+TIMEOUT /T 300 
+ 
+:COMMAND 
+
+cmd /c puppet agent --test --detailed-exitcodes --server=puppet 
+
+IF %errorlevel% EQU 0 GOTO :RM_SCH_TASK 
+
+IF %errorlevel% EQU 2 GOTO :RM_SCH_TASK 
+ 
+rem Get end time: 
+
+for /F "tokens=1-4 delims=:.," %%a in ("%time%") do ( 
+
+   set /A "end=(((%%a*60)+1%%b %% 100)*60+1%%c %% 100)*100+1%%d %% 100" 
+)
+ 
+rem Get elapsed time: 
+
+set /A elapsed=((end-start)/10)/10 
+ 
+GOTO :RUN 
+ 
+:RM_SCH_TASK 
+
+schtasks /delete /TN RUNPUPPET /F 
+
+shutdown /s /t 0 /c "userdata run complete" /f /d p:4:1 
+
+</script>

--- a/configs/try-2008
+++ b/configs/try-2008
@@ -1,0 +1,60 @@
+{
+    "hostname": "try-2008-ec2-%03d",
+    "us-east-1": {
+        "type": "try-2008",
+        "domain": "try.releng.use1.mozilla.com",
+        "ami": "ami-1d47b276",
+        "subnet_ids": ["subnet-27a9834c", "subnet-39a98352", "subnet-3ea98355", "subnet-93b285e7", "subnet-e5bacacd", "subnet-cd83d28b"],
+        "security_group_ids": [
+            "sg-18a07677",
+            "sg-718b1214"
+        ],
+        "instance_type": "r3.xlarge",
+        "distro": "win2008",
+        "ssh_key": "aws-releng",
+        "user_data_file": "../../configs/try-2008.cmd.user_data",
+        "use_public_ip": true,
+        "instance_profile_name": "try-2008",
+        "device_map": {
+            "/dev/sda1": {
+                "delete_on_termination": true,
+                "skip_resize": true,
+                "volume_type": "gp2",
+                "size": 80,
+                "instance_dev": "C:"
+            }
+        },
+        "tags": {
+            "moz-type": "try-2008"
+        }
+    },
+    "us-west-2": {
+        "type": "try-2008",
+        "domain": "try.releng.usw2.mozilla.com",
+        "ami": "ami-9b8bb3ab",
+        "subnet_ids": ["subnet-ae48dac7", "subnet-a348daca", "subnet-a448dacd", "subnet-72b68206"],
+        "security_group_ids": [
+            "sg-3aaa095f",
+            "sg-84beade6"
+        ],
+        "instance_type": "r3.xlarge",
+        "distro": "win2008",
+        "ssh_key": "aws-releng",
+        "user_data_file": "../../configs/try-2008.cmd.user_data",
+        "use_public_ip": true,
+        "instance_profile_name": "try-2008",
+        "device_map": {
+            "/dev/sda1": {
+                "delete_on_termination": true,
+                "skip_resize": true,
+                "volume_type": "gp2",
+                "size": 80,
+                "instance_dev": "C:"
+            }
+        },
+        "tags": {
+            "moz-type": "try-2008"
+        }
+    }
+
+}

--- a/configs/try-2008.cmd.user_data
+++ b/configs/try-2008.cmd.user_data
@@ -1,0 +1,72 @@
+<script>
+set FACTER_domain=try.releng.use1.mozilla.com
+
+set FACTER_hostname=try-2008-ec2-golden
+
+set FACTER_fqdn=try-2008-ec2-golden.try.releng.use1.mozilla.com
+
+set COMPUTERNAME=try-2008-ec2-golden
+
+setx FACTER_domain try.releng.use1.mozilla.com
+
+setx FACTER_hostname try-2008-ec2-golden
+
+setx FACTER_fqdn try-2008-ec2-golden.try.releng.use1.mozilla.com
+
+setx COMPUTERNAME try-2008-ec2-golden
+
+
+
+sc delete puppet 
+
+cscript.exe C:\ProgramData\Puppetlabs\puppet\var\puppettize_TEMP.vbs" 
+
+cd "C:\Program Files (x86)\Puppet Labs\Puppet\bin" 
+
+rem Get start time: 
+
+for /F "tokens=1-4 delims=:.," %%a in ("%time%") do ( 
+
+   set /A "start=(((%%a*60)+1%%b %% 100)*60+1%%c %% 100)*100+1%%d %% 100
+)
+ 
+Set /A elapsed=0 
+ 
+:RUN 
+ 
+IF %elapsed% lss 600 GOTO :COMMAND ( 
+
+IF %elapsed% gtr 600 GOTO :WAIT ( 
+ 
+:WAIT 
+
+TIMEOUT /T 300 
+ 
+:COMMAND 
+
+cmd /c puppet agent --test --detailed-exitcodes --server=puppet 
+
+IF %errorlevel% EQU 0 GOTO :RM_SCH_TASK 
+
+IF %errorlevel% EQU 2 GOTO :RM_SCH_TASK 
+ 
+rem Get end time: 
+
+for /F "tokens=1-4 delims=:.," %%a in ("%time%") do ( 
+
+   set /A "end=(((%%a*60)+1%%b %% 100)*60+1%%c %% 100)*100+1%%d %% 100" 
+)
+ 
+rem Get elapsed time: 
+
+set /A elapsed=((end-start)/10)/10 
+ 
+GOTO :RUN 
+ 
+:RM_SCH_TASK 
+
+schtasks /delete /TN RUNPUPPET /F 
+
+shutdown /r /t 0 /c "userdata run complete" /f /d p:4:1 
+
+</script>


### PR DESCRIPTION
These changes introduce 2 machine and userdata configs for windows 2008 build and try golden images. cloudtools/aws/ami.py was also modified to remove unix path cleanup which is not applicable on windows.