### PR TITLE
Bug 1160717 - let watch pending know about horizon builds

### DIFF
--- a/configs/watch_pending.cfg
+++ b/configs/watch_pending.cfg
@@ -18,6 +18,7 @@
         "^Firefox (mozilla-central|mozilla-aurora|gum) linux(64)? l10n nightly": "bld-linux64",
         "^Thunderbird (comm-central|comm-aurora) linux(64)? l10n nightly": "bld-linux64",
         "^graphene_(?!try)\\S+_linux(32|64)(-debug)?": "bld-linux64",
+        "^horizon_(?!try)\\S+_linux(32|64)(-debug)?": "bld-linux64",
         "^b2g_try_linux(32|64)_gecko(-debug)?": "try-linux64",
         "^Ubuntu VM 12.04 (?!x64).*": "tst-linux32",
         "^Ubuntu (Code Coverage )?VM 12.04 x64.*": "tst-linux64",


### PR DESCRIPTION
These builds are a different variant based on graphene. Since they'll be running on AWS instances, watch pending should know about them.