### PR TITLE
bug 1173786; modify security groups for windows

### DIFF
--- a/configs/securitygroups.yml
+++ b/configs/securitygroups.yml
@@ -141,10 +141,13 @@ build:
         instances:
             tags:
                 - [moz-type, bld-linux64]
+                - [moz-type, b-2008]
                 - [Name, bld-linux64-ec2-*]
+                - [Name, b-2008-ec2-*]
         interfaces:
             tags:
                 - [moz-type, bld-linux64]
+                - [moz-type, b-2008]
     inbound:
         include: slave-vlan-inbound
     outbound:
@@ -160,10 +163,13 @@ try:
         instances:
             tags:
                 - [moz-type, try-linux64]
+                - [moz-type, try-2008]
                 - [Name, try-linux64-ec2-*]
+                - [Name, try-2008-ec2-*]
         interfaces:
             tags:
                 - [moz-type, try-linux64]
+                - [moz-type, try-2008]
     inbound:
         include: slave-vlan-inbound
     outbound:


### PR DESCRIPTION
Instead of having a separate security group for windows to allow RDP and VNC, just properly adding them to the correct existing security groups should give them full access from the admin hosts.
Rail, is this the proper syntax to add additional tags that this sg should apply to?