### PR TITLE
Bug 1173786: removed security groups sg-18a07677 and sg-84beade6

### DIFF
--- a/configs/b-2008
+++ b/configs/b-2008
@@ -4,9 +4,16 @@
         "type": "b-2008",
         "domain": "build.releng.use1.mozilla.com",
         "ami": "ami-1d47b276",
-        "subnet_ids": ["subnet-2ba98340", "subnet-2da98346", "subnet-22a98349", "subnet-0822004e", "subnet-2da98346", "subnet-5bc7c62f", "subnet-7091d358"],
+        "subnet_ids": [
+            "subnet-2ba98340",
+            "subnet-2da98346",
+            "subnet-22a98349",
+            "subnet-0822004e",
+            "subnet-2da98346",
+            "subnet-5bc7c62f",
+            "subnet-7091d358"
+        ],
         "security_group_ids": [
-            "sg-18a07677",
             "sg-e758e982"
         ],
         "instance_type": "r3.xlarge",
@@ -32,10 +39,14 @@
         "type": "b-2008",
         "domain": "build.releng.usw2.mozilla.com",
         "ami": "ami-9b8bb3ab",
-        "subnet_ids": ["subnet-d748dabe", "subnet-a848dac1", "subnet-ad48dac4", "subnet-c74f48b3"],
+        "subnet_ids": [
+            "subnet-d748dabe",
+            "subnet-a848dac1",
+            "subnet-ad48dac4",
+            "subnet-c74f48b3"
+        ],
         "security_group_ids": [
-            "sg-f5ca0690",
-            "sg-84beade6"
+            "sg-f5ca0690"
         ],
         "instance_type": "r3.xlarge",
         "distro": "win2008",
@@ -56,5 +67,4 @@
             "moz-type": "b-2008"
         }
     }
-
 }

--- a/configs/try-2008
+++ b/configs/try-2008
@@ -4,9 +4,15 @@
         "type": "try-2008",
         "domain": "try.releng.use1.mozilla.com",
         "ami": "ami-1d47b276",
-        "subnet_ids": ["subnet-27a9834c", "subnet-39a98352", "subnet-3ea98355", "subnet-93b285e7", "subnet-e5bacacd", "subnet-cd83d28b"],
+        "subnet_ids": [
+            "subnet-27a9834c",
+            "subnet-39a98352",
+            "subnet-3ea98355",
+            "subnet-93b285e7",
+            "subnet-e5bacacd",
+            "subnet-cd83d28b"
+        ],
         "security_group_ids": [
-            "sg-18a07677",
             "sg-718b1214"
         ],
         "instance_type": "r3.xlarge",
@@ -32,10 +38,14 @@
         "type": "try-2008",
         "domain": "try.releng.usw2.mozilla.com",
         "ami": "ami-9b8bb3ab",
-        "subnet_ids": ["subnet-ae48dac7", "subnet-a348daca", "subnet-a448dacd", "subnet-72b68206"],
+        "subnet_ids": [
+            "subnet-ae48dac7",
+            "subnet-a348daca",
+            "subnet-a448dacd",
+            "subnet-72b68206"
+        ],
         "security_group_ids": [
-            "sg-3aaa095f",
-            "sg-84beade6"
+            "sg-3aaa095f"
         ],
         "instance_type": "r3.xlarge",
         "distro": "win2008",
@@ -56,5 +66,4 @@
             "moz-type": "try-2008"
         }
     }
-
 }


### PR DESCRIPTION
This PR addresses https://bugzilla.mozilla.org/show_bug.cgi?id=1173786, by removing security groups: sg-18a07677 and sg-84beade6. There was some whitespace tyding required in the same files.