### PR TITLE
reverted PR 89 until slavealloc update

### DIFF
--- a/cloudtools/slavealloc.py
+++ b/cloudtools/slavealloc.py
@@ -89,22 +89,6 @@ def slave_moz_type(slave):
        slave.get("trustlevel") == "try":
         return "tst-emulator64"
 
-    # b-2008
-    if slave.get("bitlength") == "64" and \
-       slave.get("environment") == "prod" and \
-       slave.get("distro") == "win2k8" and \
-       slave.get("purpose") == "build" and \
-       slave.get("trustlevel") == "core":
-        return "b-2008"
-
-    # try-2008
-    if slave.get("bitlength") == "64" and \
-       slave.get("environment") == "prod" and \
-       slave.get("distro") == "win2k8" and \
-       slave.get("purpose") == "build" and \
-       slave.get("trustlevel") == "try":
-        return "try-2008"
-
     return None
 
 

--- a/configs/watch_pending.cfg
+++ b/configs/watch_pending.cfg
@@ -16,16 +16,9 @@
         "^b2g_try_(emulator|emulator-jb|emulator-jb|emulator-l|emulator-kk)(-debug)?_(dep|nightly|nonunified)": "try-linux64",
         "^b2g_(?!try)\\S+_linux(32|64)_gecko(-debug)?": "bld-linux64",
         "^Firefox (mozilla-central|mozilla-aurora|gum) linux(64)? l10n nightly": "bld-linux64",
-        "^Firefox \\S+ win(32|64) l10n nightly": "b-2008",
         "^Thunderbird (comm-central|comm-aurora) linux(64)? l10n nightly": "bld-linux64",
-        "^Thunderbird \\S+ win(32|64) l10n nightly": "b-2008",
         "^graphene_(?!try)\\S+_linux(32|64)(-debug)?": "bld-linux64",
-        "^graphene_(?!try)\\S+_win(32|64)": "b-2008",
-        "^graphene_try\\S+_win(32|64)": "try-2008",
         "^horizon_(?!try)\\S+_linux(32|64)(-debug)?": "bld-linux64",
-        "^(TB )?WINNT (5.2|6.1|6.2)( x86-64)?(.*(?! try)).* (pgo-)?build": "b-2008",
-        "^(TB )?WINNT (5.2|6.1|6.2)( x86-64)?.* nightly": "b-2008",
-        "^(TB )?WINNT (5.2|6.1|6.2)( x86-64)? try": "try-2008",
         "^b2g_try_linux(32|64)_gecko(-debug)?": "try-linux64",
         "^Ubuntu VM 12.04 (?!x64).*": "tst-linux32",
         "^Ubuntu (Code Coverage )?VM 12.04 x64.*": "tst-linux64",
@@ -47,18 +40,6 @@
     },
     "spot": {
         "rules": {
-            "b-2008": [
-                {"instance_type": "c3.2xlarge",
-                 "ignored_azs": ["us-east-1b", "us-east-1e"],
-                 "performance_constant": 1,
-                 "bid_price": 0.40}
-            ],
-            "try-2008": [
-                {"instance_type": "c3.2xlarge",
-                 "ignored_azs": ["us-east-1b", "us-east-1e"],
-                 "performance_constant": 1,
-                 "bid_price": 0.40}
-            ],
             "tst-linux64": [
                 {"instance_type": "m1.medium",
                  "ignored_azs": ["us-east-1b", "us-east-1e"],
@@ -171,27 +152,21 @@
                 "tst-linux64": 2500,
                 "tst-linux32": 999,
                 "tst-emulator64": 1300,
-                "bld-linux64": 600,
-                "b-2008": 0,
-                "try-2008": 0
+                "bld-linux64": 600
             },
             "us-east-1": {
                 "tst-linux64": 1200,
                 "tst-linux32": 666,
                 "tst-emulator64": 1000,
                 "bld-linux64": 400,
-                "try-linux64": 200,
-                "b-2008": 0,
-                "try-2008": 0
+                "try-linux64": 200
             },
             "us-west-2": {
                 "tst-linux64": 1200,
                 "tst-linux32": 666,
                 "tst-emulator64": 1000,
                 "bld-linux64": 400,
-                "try-linux64": 200,
-                "b-2008": 0,
-                "try-2008": 0
+                "try-linux64": 200
             }
         }
     },
@@ -202,27 +177,21 @@
                 "tst-linux32": 0,
                 "tst-emulator64": 0,
                 "try-linux64": 0,
-                "bld-linux64": 0,
-                "b-2008": 0,
-                "try-2008": 0
+                "bld-linux64": 0
             },
             "us-east-1": {
                 "tst-linux64": 0,
                 "tst-linux32": 0,
                 "tst-emulator64": 0,
                 "try-linux64": 0,
-                "bld-linux64": 0,
-                "b-2008": 0,
-                "try-2008": 0
+                "bld-linux64": 0
             },
             "us-west-2": {
                 "tst-linux64": 0,
                 "tst-linux32": 0,
                 "tst-emulator64": 0,
                 "try-linux64": 0,
-                "bld-linux64": 0,
-                "b-2008": 0,
-                "try-2008": 0
+                "bld-linux64": 0
             }
         }
     },


### PR DESCRIPTION
I jumped the gun on https://github.com/mozilla/build-cloud-tools/pull/89, which requires a modification to slavealloc (http://slavealloc.pvt.build.mozilla.org/api/slaves) before 2008 spot allocation will work.
This PR just reverts 89 to remove 2008 from slavealloc.py & watch_pending.cfg