### PR TITLE
Bug 1191717: leave win userdata intact during ami capture (assimilate_windows)

### DIFF
--- a/cloudtools/aws/instance.py
+++ b/cloudtools/aws/instance.py
@@ -183,13 +183,9 @@ def assimilate_instance(instance, config, ssh_key, instance_data, deploypass,
 
 
 def assimilate_windows(instance, config, instance_data):
-    # Wait for the instance to stop, and then clear its userData and start it
-    # again
+    # Wait for the instance to stop, and then start it again
     log.info("waiting for instance to shut down")
     wait_for_status(instance, 'state', 'stopped', 'update')
-
-    log.info("clearing userData")
-    instance.modify_attribute("userData", None)
     log.info("starting instance")
     instance.start()
     log.info("waiting for instance to start")

--- a/configs/b-2008.user-data
+++ b/configs/b-2008.user-data
@@ -116,6 +116,31 @@ function Send-Log {{
   Send-MailMessage -To $to -Subject $subject -Body ([IO.File]::ReadAllText($logfile)) -SmtpServer $smtpServer -From $from
 }}
 
+function Enable-UserdataPersist {{
+  <#
+  .Synopsis
+    Sets Ec2ConfigService Ec2HandleUserData to enabled in config.
+  .Description
+    Modifies Ec2ConfigService config file and logs settings at time of check.
+  .Parameter ec2SettingsFile
+    The full path to the config file for Ec2ConfigService.
+  #>
+  param (
+    [string] $ec2SettingsFile = "C:\Program Files\Amazon\Ec2ConfigService\Settings\Config.xml"
+  )
+  [xml]$xml = (Get-Content $ec2SettingsFile)
+  foreach ($plugin in $xml.DocumentElement.Plugins.Plugin) {{
+    Write-Log -message ('plugin state of {{0}} read as: {{1}}, in: {{2}}' -f $plugin.Name, $plugin.State, $ec2SettingsFile) -severity 'DEBUG'
+    if ($plugin.Name -eq "Ec2HandleUserData") {{
+      if ($plugin.State -ne "Enabled") {{
+        Write-Log -message ('changing state of Ec2HandleUserData plugin from: {{0}} to: Enabled, in: {{1}}' -f $plugin.State, $ec2SettingsFile) -severity 'INFO'
+        $plugin.State = "Enabled"
+      }}
+    }}
+  }}
+  $xml.Save($ec2SettingsFile)
+}}
+
 function Stop-ComputerWithDelay {{
   <#
   .Synopsis
@@ -387,6 +412,7 @@ if ($hostnameCorrect -and $domainCorrect) {{
   if ($domainCorrect -ne $true) {{ Set-Domain -domain $domain }}
   Stop-ComputerWithDelay -reason 'host name changed' -restart
 }}
+Enable-UserdataPersist
 
 Send-Log -logfile ('{{0}}\Amazon\Ec2ConfigService\Logs\Ec2ConfigLog.txt' -f $env:ProgramFiles) -subject ('EC2 Config Report for {{0}}.{{1}}' -f $hostname, $domain)
 Send-Log -logfile $global:runLog -subject ('UserData Run Report for {{0}}.{{1}}' -f $hostname, $domain)


### PR DESCRIPTION
Removed `instance.modify_attribute("userData", None) ` from instance.py which was causing ec2config to override the userdata persistence setting.
Also, added a check to userdata powershell to monitor and correct the setting if needed on each run.