### PR TITLE
Bug: 1192234: reinstated token: moz_instance_type

### DIFF
--- a/cloudtools/scripts/aws_watch_pending.py
+++ b/cloudtools/scripts/aws_watch_pending.py
@@ -307,6 +307,7 @@ def do_request_instance(region, moz_instance_type, price, ami, instance_config,
     nc = NetworkInterfaceCollection(spec)
 
     user_data = user_data_from_template(moz_instance_type, {
+        "moz_instance_type": moz_instance_type,
         "hostname": name,
         "domain": instance_config[region]["domain"],
         "fqdn": fqdn,


### PR DESCRIPTION
I missed a token during earlier refactoring for https://github.com/mozilla/build-cloud-tools/pull/96