### PR TITLE
Revert product_description back to Linux

### DIFF
--- a/cloudtools/scripts/aws_watch_pending.py
+++ b/cloudtools/scripts/aws_watch_pending.py
@@ -138,8 +138,6 @@ def aws_resume_instances(all_instances, moz_instance_type, start_count,
 def get_product_description(moz_instance_type):
     # http://docs.aws.amazon.com/sdkforruby/api/Aws/EC2/Types/DescribeReservedInstancesOfferingsRequest.html
     # https://boto3.readthedocs.org/en/latest/reference/services/ec2.html#EC2.Client.request_spot_instances
-    if moz_instance_type in ["y-2008", "b-2008"]:
-        return "Windows (Amazon VPC)"
     return "Linux/UNIX (Amazon VPC)"
 
 


### PR DESCRIPTION
We still haven't seen any y-2008 spot instances spin up. One change that was made around the time we stopped getting spin ups was https://github.com/mozilla/build-cloud-tools/pull/100 which was an effort to correctly label the product_description (platform) in EC2 as "Windows (Amazon VPC)" instead of "Linux/UNIX (Amazon VPC)". We need to experiment with reverting this change to see if it is what caused the lack of y-2008 spot spin ups.

https://bugzilla.mozilla.org/show_bug.cgi?id=1191717#c8