### PR TITLE
Bug 1191717: set puppet server; r=rail

### DIFF
--- a/cloudtools/scripts/aws_create_instance.py
+++ b/cloudtools/scripts/aws_create_instance.py
@@ -15,7 +15,8 @@ from cloudtools.aws import get_aws_connection, get_vpc, \
     name_available, wait_for_status, get_region_dns_atom
 from cloudtools.dns import get_ip, get_ptr
 from cloudtools.aws.instance import assimilate_instance, \
-    make_instance_interfaces, user_data_from_template
+    make_instance_interfaces, user_data_from_template, \
+    pick_puppet_master
 from cloudtools.aws.vpc import get_subnet_id, ip_available
 from cloudtools.aws.ami import ami_cleanup, volume_to_ami, copy_ami, \
     get_ami
@@ -108,8 +109,9 @@ def create_instance(name, config, region, key_name, ssh_key, instance_data,
     keep_going, attempt = True, 1
     while keep_going:
         try:
+            puppet_master = pick_puppet_master(instance_data.get('puppet_masters'))
             user_data = user_data_from_template(config['type'], {
-                "puppet_server": instance_data.get('default_puppet_server'),
+                "puppet_server": puppet_master,
                 "fqdn": instance_data['hostname'],
                 "hostname": instance_data['name'],
                 "domain": instance_data['domain'],


### PR DESCRIPTION
Windows spot instantiation is failing at this step with:

2015-08-18 07:36:20,226 - Spot request for y-2008-spot-001.try.releng.use1.mozilla.com (0.4)
2015-08-18 07:36:20,227 - Cannot start
Traceback (most recent call last):
  File "aws_watch_pending.py", line 266, in do_request_spot_instances
    is_spot=True, dryrun=dryrun, all_instances=all_instances)
  File "aws_watch_pending.py", line 320, in do_request_instance
    "region_dns_atom": get_region_dns_atom(region)})
  File "/builds/aws_manager/cloud-tools/cloudtools/aws/instance.py", line 311, in user_data_from_template
    user_data = user_data.format(**tokens)
KeyError: 'puppet_server'

This PR will hopefully fix this issue.