### PR TITLE
disable token temporarily

### DIFF
--- a/configs/b-2008.user-data
+++ b/configs/b-2008.user-data
@@ -53,7 +53,7 @@ param (
   # accept tokens from cloud-tools (change tokens to actual values if running outside cloud-tools)
   [string] $hostname = '{hostname}',
   [string] $domain = '{domain}',
-  [string] $puppetServer = '{puppet_server}',
+  #[string] $puppetServer = '{{puppet_server}}',
   [string] $aggregator = 'log-aggregator.srv.releng.{region_dns_atom}.mozilla.com',
 
   # runtime configuration


### PR DESCRIPTION
Still getting errors in aws_watch_pending.log related to the {puppet_server} token. removing it from powershell, to see if this prevents the exception.