### PR TITLE
Bug 1198317: increase max bid for y-2008 instances

### DIFF
--- a/configs/watch_pending.cfg
+++ b/configs/watch_pending.cfg
@@ -59,7 +59,7 @@
                 {"instance_type": "c3.2xlarge",
                  "ignored_azs": ["us-east-1b", "us-east-1e"],
                  "performance_constant": 1,
-                 "bid_price": 0.40}
+                 "bid_price": 0.50}
             ],
             "tst-linux64": [
                 {"instance_type": "m1.medium",


### PR DESCRIPTION
Watch pending is failing to instantiate y-2008 spot instances due to the pricing rules. This is a temporary max bid increase to enable us to get on with testing for https://bugzilla.mozilla.org/show_bug.cgi?id=1198317

2015-08-26 23:06:01,897 - getting all spot requests for us-east-1
2015-08-26 23:06:07,692 - 0 active spot requests for us-east-1 y-2008
2015-08-26 23:06:07,697 - 0 real active spot requests for us-east-1 y-2008
2015-08-26 23:06:07,992 - Sanity checking c3.2xlarge in us-west-2a
2015-08-26 23:06:07,992 - Price is higher than 80% of ours, c3.2xlarge (us-west-2, us-west-2a) 0.3961 (value: 0.3961) < 0.4
2015-08-26 23:06:07,993 - Skipping c3.2xlarge (us-west-2, us-west-2a) 0.3961 (value: 0.3961) < 0.4 for us-west-2 - unusable
2015-08-26 23:06:07,993 - Sanity checking c3.2xlarge in us-west-2c
2015-08-26 23:06:07,993 - Price is higher than 80% of ours, c3.2xlarge (us-west-2, us-west-2c) 0.3961 (value: 0.3961) < 0.4
2015-08-26 23:06:07,993 - Skipping c3.2xlarge (us-west-2, us-west-2c) 0.3961 (value: 0.3961) < 0.4 for us-west-2 - unusable
2015-08-26 23:06:07,993 - Sanity checking c3.2xlarge in us-west-2b
2015-08-26 23:06:07,993 - Price is higher than 80% of ours, c3.2xlarge (us-west-2, us-west-2b) 0.3961 (value: 0.3961) < 0.4
2015-08-26 23:06:07,993 - Skipping c3.2xlarge (us-west-2, us-west-2b) 0.3961 (value: 0.3961) < 0.4 for us-west-2 - unusable
2015-08-26 23:06:07,993 - Sanity checking c3.2xlarge in us-east-1c
2015-08-26 23:06:07,994 - Price is higher than 80% of ours, c3.2xlarge (us-east-1, us-east-1c) 0.3985 (value: 0.3985) < 0.4
2015-08-26 23:06:08,000 - Skipping c3.2xlarge (us-east-1, us-east-1c) 0.3985 (value: 0.3985) < 0.4 for us-east-1 - unusable
2015-08-26 23:06:08,000 - Sanity checking c3.2xlarge in us-east-1a
2015-08-26 23:06:08,000 - Price is higher than 80% of ours, c3.2xlarge (us-east-1, us-east-1a) 0.3988 (value: 0.3988) < 0.4
2015-08-26 23:06:08,000 - Skipping c3.2xlarge (us-east-1, us-east-1a) 0.3988 (value: 0.3988) < 0.4 for us-east-1 - unusable
2015-08-26 23:06:08,000 - Sanity checking c3.2xlarge in us-east-1d
2015-08-26 23:06:08,000 - Price is higher than 80% of ours, c3.2xlarge (us-east-1, us-east-1d) 0.4 (value: 0.4) < 0.4
2015-08-26 23:06:08,001 - Skipping c3.2xlarge (us-east-1, us-east-1d) 0.4 (value: 0.4) < 0.4 for us-east-1 - unusable
2015-08-26 23:06:08,001 - y-2008 - started 0 spot instances for slaveset None; need 43
2015-08-26 23:06:08,001 - need 43 ondemand y-2008 for slaveset None
2015-08-26 23:06:08,027 - 0 y-2008 ondemand instances running globally