### PR TITLE
bump up max bid for (b|y)-2008

### DIFF
--- a/configs/watch_pending.cfg
+++ b/configs/watch_pending.cfg
@@ -53,13 +53,13 @@
                 {"instance_type": "c3.2xlarge",
                  "ignored_azs": ["us-east-1b", "us-east-1e"],
                  "performance_constant": 1,
-                 "bid_price": 0.40}
+                 "bid_price": 0.70}
             ],
             "y-2008": [
                 {"instance_type": "c3.2xlarge",
                  "ignored_azs": ["us-east-1b", "us-east-1e"],
                  "performance_constant": 1,
-                 "bid_price": 0.50}
+                 "bid_price": 0.70}
             ],
             "tst-linux64": [
                 {"instance_type": "m1.medium",


### PR DESCRIPTION
following an irc conversation with @rail, set a more sensible max bid for Windows 2008 c3.2xlarge