### PR TITLE
Bug 1199267: disable windows firewall (rely on ec2 Security Groups)

### DIFF
--- a/configs/Ec2UserdataUtils.psm1
+++ b/configs/Ec2UserdataUtils.psm1
@@ -387,3 +387,23 @@ function Set-Aggregator {
     Write-Log -message "log aggregator set to: $aggregator" -severity 'INFO'
   }
 }
+
+function Disable-Firewall {
+  <#
+  .Synopsis
+    Disables the Windows Firewall for the specified profile.
+  .Parameter profile
+    The profile to disable the firewall under. Defaults to CurrentProfile.
+  #>
+  param (
+    [string] $profile = 'AllProfiles'
+  )
+  Write-Log -message 'disabling Windows Firewall' -severity 'INFO'
+  $netshArgs = @('advfirewall', 'set', $profile, 'state', 'off')
+  & 'netsh' $netshArgs
+  #Set-ItemProperty -path HKLM:\Software\Policies\Microsoft\WindowsFirewall\DomainProfile -name EnableFirewall -value 0
+  #Set-ItemProperty -path HKLM:\Software\Policies\Microsoft\WindowsFirewall\PrivateProfile -name EnableFirewall -value 0
+  #Set-ItemProperty -path HKLM:\Software\Policies\Microsoft\WindowsFirewall\PublicProfile -name EnableFirewall -value 0
+  # setting the keys above has no effect due to a group policy setting. removing the section, has the desired effect.
+  Remove-Item -path HKLM:\Software\Policies\Microsoft\WindowsFirewall -recurse -force
+}

--- a/configs/b-2008.user-data
+++ b/configs/b-2008.user-data
@@ -97,6 +97,7 @@ Import-Module Ec2UserdataUtils
 
 # create the log directory if it doesn't exist
 New-Item -ItemType Directory -Force -Path $logDir
+Disable-Firewall 
 Disable-WindowsUpdate
 Disable-PuppetService
 $hostnameCorrect = (Is-HostnameSetCorrectly -hostnameExpected $hostname)


### PR DESCRIPTION
Further to conversations in #specops, we need to experiment with disabling the Windows firewall to determine if it is causing the hg clone failures.