### PR TITLE
check for reg key before delete attempt and fix xml hostname update

### DIFF
--- a/configs/Ec2UserdataUtils.psm1
+++ b/configs/Ec2UserdataUtils.psm1
@@ -301,8 +301,8 @@ function Set-Hostname {
             $computerNameElement.AppendChild($xml.CreateTextNode("$hostname"))
             $component.AppendChild($computerNameElement)
             Write-Log -message ('computer name inserted to: {0}' -f $sysprepFile) -severity 'DEBUG'
-          } else {
-            $component.ComputerName.value = "$hostname"
+          } else if ($component.ComputerName.InnerText -ne "$hostname") {
+            $component.ComputerName.InnerText = "$hostname"
             Write-Log -message ('computer name updated in: {0}' -f $sysprepFile) -severity 'DEBUG'
           }
         }
@@ -396,14 +396,14 @@ function Disable-Firewall {
     The profile to disable the firewall under. Defaults to CurrentProfile.
   #>
   param (
-    [string] $profile = 'AllProfiles'
+    [string] $profile = 'AllProfiles',
+    [string] $registryKey = 'HKLM:\Software\Policies\Microsoft\WindowsFirewall'
   )
   Write-Log -message 'disabling Windows Firewall' -severity 'INFO'
   $netshArgs = @('advfirewall', 'set', $profile, 'state', 'off')
   & 'netsh' $netshArgs
-  #Set-ItemProperty -path HKLM:\Software\Policies\Microsoft\WindowsFirewall\DomainProfile -name EnableFirewall -value 0
-  #Set-ItemProperty -path HKLM:\Software\Policies\Microsoft\WindowsFirewall\PrivateProfile -name EnableFirewall -value 0
-  #Set-ItemProperty -path HKLM:\Software\Policies\Microsoft\WindowsFirewall\PublicProfile -name EnableFirewall -value 0
-  # setting the keys above has no effect due to a group policy setting. removing the section, has the desired effect.
-  Remove-Item -path HKLM:\Software\Policies\Microsoft\WindowsFirewall -recurse -force
+  if (Test-Path $registryKey) {
+    Write-Log -message 'removing Windows Firewall registry entries' -severity 'INFO'
+    Remove-Item -path $registryKey -recurse -force
+  }
 }


### PR DESCRIPTION
we get a couple of frequent exceptions in ec2config logs. this pr addresses this by introducing a check for the existence of a registry key before attempting to delete it and a correction to an xml property setter.