### PR TITLE
Bug 1205640: purge event log before golden ami capture

### DIFF
--- a/configs/Ec2UserdataUtils.psm1
+++ b/configs/Ec2UserdataUtils.psm1
@@ -409,3 +409,12 @@ function Disable-Firewall {
     Remove-Item -path $registryKey -recurse -force
   }
 }
+
+function Flush-EventLog {
+  <#
+  .Synopsis
+    Removes all entries from the event log. Used right before golden ami capture for a clean slate image.
+  #>
+  Write-Log -message 'flushing the Windows EventLog' -severity 'INFO'
+  wevtutil el | % { wevtutil cl $_ }
+}

--- a/configs/b-2008.user-data
+++ b/configs/b-2008.user-data
@@ -120,6 +120,7 @@ if ($hostnameCorrect -and $domainCorrect) {{
     #Run-Puppet -hostname $hostname -domain $domain -puppetServer $puppetServer -logdest $puppetLog
     Run-Puppet -hostname $hostname -domain $domain -logdest $puppetLog
     Send-Log -logfile $puppetLog -subject ('Puppet Agent Report for {{0}}.{{1}}' -f $hostname, $domain) -to $logRecipients -from $logSender
+    Flush-EventLog
     Stop-ComputerWithDelay -reason 'userdata golden puppet run complete'
   }}
 }} else {{


### PR DESCRIPTION
there is a lot of noise in the event log from the parent (golden/base) amis. this pr adds a purge step to the ami capture to discard this noise before generating clean amis.