### PR TITLE
Use second disk for dev build isntances

### DIFF
--- a/configs/dev-linux64
+++ b/configs/dev-linux64
@@ -13,10 +13,14 @@
         "instance_profile_name": "try-linux64",
         "device_map": {
             "/dev/xvda": {
-                "size": 250,
                 "delete_on_termination": true,
                 "skip_resize": true,
                 "instance_dev": "/dev/xvda1"
+            },
+            "/dev/xvdb": {
+                "size": 150,
+                "delete_on_termination": true,
+                "skip_resize": true
             }
         }
     },
@@ -33,10 +37,14 @@
         "instance_profile_name": "try-linux64",
         "device_map": {
             "/dev/xvda": {
-                "size": 250,
                 "delete_on_termination": true,
                 "skip_resize": true,
                 "instance_dev": "/dev/xvda1"
+            },
+            "/dev/xvdb": {
+                "size": 150,
+                "delete_on_termination": true,
+                "skip_resize": true
             }
         }
     }


### PR DESCRIPTION
This will create second EBS disk, which can be added to LVM using following commands:
```bash
pvcreate /dev/xvdb
vgextend cloud_root /dev/xvdb
lvextend -l 100%VG /dev/cloud_root/lv_root
resize2fs /dev/cloud_root/lv_root
```