### PR TITLE
Bug 1145774, Use 2xlarge or bigger instances for av scans, and swap to ondemand

### DIFF
--- a/configs/watch_pending.cfg
+++ b/configs/watch_pending.cfg
@@ -130,18 +130,6 @@
                  "bid_price": 0.18}
             ],
             "av-linux64": [
-                {"instance_type": "c3.xlarge",
-                 "ignored_azs": ["us-east-1b", "us-east-1e"],
-                 "performance_constant": 1,
-                 "bid_price": 0.18},
-                {"instance_type": "m3.xlarge",
-                 "performance_constant": 1.1,
-                 "ignored_azs": ["us-east-1b", "us-east-1e"],
-                 "bid_price": 0.18},
-                {"instance_type": "r3.xlarge",
-                 "ignored_azs": ["us-east-1b", "us-east-1e"],
-                 "performance_constant": 1.2,
-                 "bid_price": 0.18},
                 {"instance_type": "r3.2xlarge",
                  "ignored_azs": ["us-east-1b", "us-east-1e"],
                  "performance_constant": 2.2,
@@ -220,7 +208,7 @@
                 "tst-linux32": 999,
                 "tst-emulator64": 1300,
                 "bld-linux64": 600,
-                "av-linux64": 2,
+                "av-linux64": 0,
                 "b-2008": 100,
                 "y-2008": 100
             },
@@ -229,7 +217,7 @@
                 "tst-linux32": 666,
                 "tst-emulator64": 1000,
                 "bld-linux64": 400,
-                "av-linux64": 1,
+                "av-linux64": 0,
                 "try-linux64": 200,
                 "b-2008": 100,
                 "y-2008": 100
@@ -239,7 +227,7 @@
                 "tst-linux32": 666,
                 "tst-emulator64": 1000,
                 "bld-linux64": 400,
-                "av-linux64": 1,
+                "av-linux64": 0,
                 "try-linux64": 200,
                 "b-2008": 100,
                 "y-2008": 100
@@ -254,7 +242,7 @@
                 "tst-emulator64": 0,
                 "try-linux64": 0,
                 "bld-linux64": 0,
-                "av-linux64": 0,
+                "av-linux64": 2,
                 "b-2008": 0,
                 "y-2008": 0
             },
@@ -264,7 +252,7 @@
                 "tst-emulator64": 0,
                 "try-linux64": 0,
                 "bld-linux64": 0,
-                "av-linux64": 0,
+                "av-linux64": 1,
                 "b-2008": 0,
                 "y-2008": 0
             },
@@ -274,7 +262,7 @@
                 "tst-emulator64": 0,
                 "try-linux64": 0,
                 "bld-linux64": 0,
-                "av-linux64": 0,
+                "av-linux64": 1,
                 "b-2008": 0,
                 "y-2008": 0
             }


### PR DESCRIPTION
As rail and I discussed today. 2xlarge will result in 160G of ephemeral storage, and more for the 4xlarge and 8xlarge, so we'll have enough space to download a full set of release builds. Swap to ondemand to not worry about getting outbid.