### PR TITLE
bug 1199267: always shutdown golden, only reboot spot on hostname change

### DIFF
--- a/configs/b-2008.user-data
+++ b/configs/b-2008.user-data
@@ -110,15 +110,18 @@ Disable-Firewall
 Disable-WindowsUpdate
 Install-BasePrerequisites -aggregator $aggregator
 Rename-Admin
+if ($hostname.Contains("-golden")) {{
+  Prep-Golden -moztype $hostname.Replace('-ec2-golden', '')
+}}
 if ((!(Is-HostnameSetCorrectly -hostnameExpected $hostname)) -or (!(Is-DomainSetCorrectly -domainExpected $domain))) {{
   Set-Hostname -hostname $hostname
   Set-Domain -domain $domain
+  if (!($hostname.Contains("-golden"))) {{
+    Stop-ComputerWithDelay -reason 'userdata run complete, host renamed' -restart
+  }}
 }}
 if ($hostname.Contains("-golden")) {{
-  Prep-Golden -moztype $hostname.Replace('-ec2-golden', '')
-  Stop-ComputerWithDelay -reason 'userdata golden run complete, shutting down'
-}} else {{
-  Stop-ComputerWithDelay -reason 'userdata run complete, restarting' -restart
+  Stop-ComputerWithDelay -reason 'userdata golden run complete'
 }}
 if (!($hostname.Contains("-spot-"))) {{
   Send-Log -logfile $runLog -subject ('UserData Run Report for {{0}}.{{1}}' -f $hostname, $domain) -to 'releng-puppet-mail@mozilla.com' -from $logSender


### PR DESCRIPTION
reboot logic before was causing spot boot-loops. this pr moves the spot reboot logic back inside the host rename logic.