### PR TITLE
Bug 1226662: Prep windows loaner instances

### DIFF
--- a/configs/b-2008.user-data
+++ b/configs/b-2008.user-data
@@ -112,6 +112,8 @@ Install-BasePrerequisites -aggregator $aggregator
 Rename-Admin
 if ($hostname.Contains("-golden")) {{
   Prep-Golden
+}} elseif ($hostname -match "(b|y)-2[0-9]{{3}}-ec2-[a-z].*") {{
+  Prep-Loaner
 }}
 if ($hostname.Contains("-ec2-")) {{
   Get-SourceCaches -hostname $hostname


### PR DESCRIPTION
Add support for windows loaner instances in ec2 by:
- removing the contents of c:\users\cltbld\\.ssh
- removing the contents of c:\builds (tokens, oauth keys, etc)
- secure wipe of free space on C: drive
- generating a new random password for root, cltbld and the local vnc server
- prevent auto login of cltbld