### PR TITLE
Bug 1226662: Prep windows loaner instances

### DIFF
--- a/configs/Ec2UserdataUtils.psm1
+++ b/configs/Ec2UserdataUtils.psm1
@@ -726,11 +726,13 @@ function Prep-Loaner {
     Flush-TempFiles
     Flush-BuildFiles
     Flush-Secrets
-    $password = ([Guid]::NewGuid()).ToString().Substring(0, 8)
+    $password = (New-SWRandomPassword)
     Set-IniValue -file ('{0}\uvnc bvba\UltraVnc\ultravnc.ini' -f $env:ProgramFiles) -section 'ultravnc' -key 'passwd' -value $password
     Set-IniValue -file ('{0}\uvnc bvba\UltraVnc\ultravnc.ini' -f $env:ProgramFiles) -section 'ultravnc' -key 'passwd2' -value $password
     ([ADSI]'WinNT://./root').SetPassword("$password")
+    ([ADSI]'WinNT://./root').SetInfo()
     ([ADSI]'WinNT://./cltbld').SetPassword("$password")
+    ([ADSI]'WinNT://./cltbld').SetInfo()
     Write-Log -message ('{0} :: password set to: {1}' -f $($MyInvocation.MyCommand.Name), $password) -severity 'INFO'
     Set-RegistryValue -path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\WinLogon' -key 'AutoAdminLogon' -value 0
     Write-Log -message ("{0} :: Wiping free space" -f $($MyInvocation.MyCommand.Name)) -severity 'INFO'
@@ -1650,7 +1652,7 @@ function New-SWRandomPassword {
     
     # Specifies an array of strings containing charactergroups from which the password will be generated.
     # At least one char from each group (string) will be used.
-    [String[]]$InputStrings = @('abcdefghijkmnpqrstuvwxyz', 'ABCEFGHJKLMNPQRSTUVWXYZ', '23456789', '!"#%&'),
+    [String[]]$InputStrings = @('abcdefghijkmnpqrstuvwxyz', 'ABCEFGHJKLMNPQRSTUVWXYZ', '23456789', '!@$#%&'),
 
     # Specifies a string containing a character group from which the first character in the password will be generated.
     # Useful for systems which requires first char in password to be alphabetic.

--- a/configs/b-2008.user-data
+++ b/configs/b-2008.user-data
@@ -112,6 +112,8 @@ Install-BasePrerequisites -aggregator $aggregator
 Rename-Admin
 if ($hostname.Contains("-golden")) {{
   Prep-Golden
+}} elseif ($hostname -match "(b|y)-2[0-9]{{3}}-ec2-[a-z].*") {{
+  Prep-Loaner
 }}
 if ($hostname.Contains("-ec2-")) {{
   Get-SourceCaches -hostname $hostname

--- a/configs/b-2008.user-data
+++ b/configs/b-2008.user-data
@@ -126,6 +126,7 @@ if ((!(Is-HostnameSetCorrectly -hostnameExpected $hostname)) -or (!(Is-DomainSet
   }}
 }}
 if ($hostname.Contains("-golden")) {{
+  Flush-EventLog
   Stop-ComputerWithDelay -reason 'userdata golden run complete'
 }}
 if (!($hostname.Contains("-spot-"))) {{


### PR DESCRIPTION
Add support for windows loaner instances in ec2 by:
- removing the contents of c:\users\cltbld\.ssh
- removing the contents of c:\builds (tokens, oauth keys, etc)
- secure wipe of free space on C: drive
- generating a new random password for root, cltbld and the local vnc server 
- patches broken ini value update
- prevent auto login of cltbld