### PR TITLE
Bug 1223509

### DIFF
--- a/configs/watch_pending.cfg
+++ b/configs/watch_pending.cfg
@@ -70,7 +70,7 @@
                 {"instance_type": "g2.2xlarge",
                  "ignored_azs": ["us-east-1b", "us-east-1e"],
                  "performance_constant": 1,
-                 "bid_price": 1.00}
+                 "bid_price": 0.77}
             ],
             "tst-linux64": [
                 {"instance_type": "m1.medium",

--- a/configs/watch_pending.cfg
+++ b/configs/watch_pending.cfg
@@ -67,10 +67,10 @@
                  "bid_price": 0.70}
             ],
             "t-w732": [
-                {"instance_type": "c3.2xlarge",
+                {"instance_type": "g2.2xlarge",
                  "ignored_azs": ["us-east-1b", "us-east-1e"],
                  "performance_constant": 1,
-                 "bid_price": 0.70}
+                 "bid_price": 1.00}
             ],
             "tst-linux64": [
                 {"instance_type": "m1.medium",
@@ -216,9 +216,9 @@
                 "tst-emulator64": 1300,
                 "bld-linux64": 600,
                 "av-linux64": 2,
-                "b-2008": 100,
-                "y-2008": 100,
-                "t-w732": 100
+                "b-2008": 200,
+                "y-2008": 200,
+                "t-w732": 400
             },
             "us-east-1": {
                 "tst-linux64": 1200,
@@ -229,7 +229,7 @@
                 "try-linux64": 200,
                 "b-2008": 100,
                 "y-2008": 100,
-                "t-w732": 100
+                "t-w732": 200
             },
             "us-west-2": {
                 "tst-linux64": 1200,
@@ -240,7 +240,7 @@
                 "try-linux64": 200,
                 "b-2008": 100,
                 "y-2008": 100,
-                "t-w732": 100
+                "t-w732": 200
             }
         }
     },


### PR DESCRIPTION
- set spot bid for g2.2xlarge to $1.00 (based on 3 month historical prices for instance type)
- match win spot instance limits with slave-alloc counts (limits set with slave-alloc enable/disable)