### PR TITLE
Update ubuntu amis

### DIFF
--- a/ami_configs/releng-public-precise.list
+++ b/ami_configs/releng-public-precise.list
@@ -1,4 +1,5 @@
 deb http://puppetagain.pub.build.mozilla.org/data/repos/apt/ubuntu precise main restricted universe
 deb http://puppetagain.pub.build.mozilla.org/data/repos/apt/ubuntu precise-security main restricted universe
+deb http://puppetagain.pub.build.mozilla.org/data/repos/apt/precise-updates precise-updates main restricted universe
 deb http://puppetagain.pub.build.mozilla.org/data/repos/apt/releng precise main
 deb http://puppetagain.pub.build.mozilla.org/data/repos/apt/puppetlabs precise main dependencies

--- a/configs/tst-emulator64
+++ b/configs/tst-emulator64
@@ -3,7 +3,7 @@
     "us-east-1": {
         "type": "tst-emulator64",
         "domain": "test.releng.use1.mozilla.com",
-        "ami": "ami-e48e1e8d",
+        "ami": "ami-3a336e50",
         "subnet_ids": ["subnet-5bafe92c", "subnet-e40e0786", "subnet-ff3542d7",
                        "subnet-49981462", "subnet-f22fb5ab", "subnet-b8643190",
                        "subnet-fb97bc8f", "subnet-5cd0d828", "subnet-3835cc52",
@@ -43,7 +43,7 @@
     "us-west-2": {
         "type": "tst-emulator64",
         "domain": "test.releng.usw2.mozilla.com",
-        "ami": "ami-e00a80d0",
+        "ami": "ami-385c4459",
         "subnet_ids": ["subnet-aecba8c7", "subnet-56082710", "subnet-40b36d19",
                        "subnet-a4cba8cd", "subnet-871471e2", "subnet-737f9216",
                        "subnet-46932831", "subnet-41932836", "subnet-be89a2ca",

--- a/configs/tst-linux32
+++ b/configs/tst-linux32
@@ -3,7 +3,7 @@
     "us-east-1": {
         "type": "tst-linux32",
         "domain": "test.releng.use1.mozilla.com",
-        "ami": "ami-ea8e1e83",
+        "ami": "ami-632d7009",
         "subnet_ids": ["subnet-5bafe92c", "subnet-e40e0786", "subnet-ff3542d7",
                        "subnet-49981462", "subnet-f22fb5ab", "subnet-b8643190",
                        "subnet-fb97bc8f", "subnet-5cd0d828", "subnet-3835cc52",
@@ -31,7 +31,7 @@
     "us-west-2": {
         "type": "tst-linux32",
         "domain": "test.releng.usw2.mozilla.com",
-        "ami": "ami-040c8634",
+        "ami": "ami-df5c44be",
         "subnet_ids": ["subnet-aecba8c7", "subnet-56082710", "subnet-40b36d19",
                        "subnet-a4cba8cd", "subnet-871471e2", "subnet-737f9216",
                        "subnet-46932831", "subnet-41932836", "subnet-be89a2ca",

--- a/configs/tst-linux64
+++ b/configs/tst-linux64
@@ -3,7 +3,7 @@
     "us-east-1": {
         "type": "tst-linux64",
         "domain": "test.releng.use1.mozilla.com",
-        "ami": "ami-e48e1e8d",
+        "ami": "ami-385c4459",
         "subnet_ids": ["subnet-5bafe92c", "subnet-e40e0786", "subnet-ff3542d7",
                        "subnet-49981462", "subnet-f22fb5ab", "subnet-b8643190",
                        "subnet-fb97bc8f", "subnet-5cd0d828", "subnet-3835cc52",
@@ -31,7 +31,7 @@
     "us-west-2": {
         "type": "tst-linux64",
         "domain": "test.releng.usw2.mozilla.com",
-        "ami": "ami-e00a80d0",
+        "ami": "ami-385c4459",
         "subnet_ids": ["subnet-aecba8c7", "subnet-56082710", "subnet-40b36d19",
                        "subnet-a4cba8cd", "subnet-871471e2", "subnet-737f9216",
                        "subnet-46932831", "subnet-41932836", "subnet-be89a2ca",


### PR DESCRIPTION
Bug 1220658 - Upgrade ec2 test instances mesa versions to mesa-lts-saucy-9.2.1

Regenerated base AMIs with precise-updates enabled