### PR TITLE
Bug 1232501: set missing domain parameter for bundleclone; r=markco

### DIFF
--- a/configs/b-2008.user-data
+++ b/configs/b-2008.user-data
@@ -108,7 +108,7 @@ Set-Ec2ConfigPluginsState
 Set-Timezone
 Disable-Firewall 
 Disable-WindowsUpdate
-Install-BasePrerequisites -aggregator $aggregator
+Install-BasePrerequisites -aggregator $aggregator -domain $domain
 Rename-Admin
 if ($hostname.Contains("-golden")) {{
   Prep-Golden


### PR DESCRIPTION
this pr fixes a userdata issue where bundleclone falls back to us-east-1 when no domain info is supplied in userdata. the patch corrects this by providing the missing parameter.