### PR TITLE
Set correct Content-Type for amis.json

### DIFF
--- a/cloudtools/scripts/aws_publish_amis.py
+++ b/cloudtools/scripts/aws_publish_amis.py
@@ -44,7 +44,7 @@ def update_ami_status(data):
     conn = boto.connect_s3()
     bucket = conn.get_bucket(BUCKET)
     key = bucket.get_key(KEY)
-    key.set_contents_from_string(data)
+    key.set_contents_from_string(data, headers={'Content-Type': 'application/json'})
     key.set_acl("public-read")
 
 


### PR DESCRIPTION
https://s3.amazonaws.com/mozilla-releng-amis/amis.json is very hard to read in Firefox, and adding an extension like JSONView doesn't help because it only enables for the Content-Type of application/json. So this would fix it up, but I'm not sure what's consuming the file now and if it's going to care about the header changing from text/plain.