### PR TITLE
Bug 1242014 - Support routing for seabld productdelivery upload host.…

### DIFF
--- a/configs/routingtables.yml
+++ b/configs/routingtables.yml
@@ -40,6 +40,9 @@ us-west-2:
             upload.ffxbld.productdelivery.stage.mozaws.net: IGW
             upload.trybld.productdelivery.stage.mozaws.net: IGW
             upload.tbirdbld.productdelivery.stage.mozaws.net: IGW
+            # seabld only here to appease firewall-test complexity, no harm
+            upload.seabld.productdelivery.prod.mozaws.net: IGW
+            upload.seabld.productdelivery.stage.mozaws.net: IGW
 
             # papertrail servers
             173.247.96.0/19: IGW
@@ -191,6 +194,9 @@ us-east-1:
             upload.ffxbld.productdelivery.stage.mozaws.net: IGW
             upload.trybld.productdelivery.stage.mozaws.net: IGW
             upload.tbirdbld.productdelivery.stage.mozaws.net: IGW
+            # seabld only here to appease firewall-test complexity, no harm
+            upload.seabld.productdelivery.prod.mozaws.net: IGW
+            upload.seabld.productdelivery.stage.mozaws.net: IGW
 
             # papertrail servers
             173.247.96.0/19: IGW
@@ -255,8 +261,10 @@ us-east-1:
             aus5.mozilla.org: IGW
             upload.ffxbld.productdelivery.prod.mozaws.net: IGW
             upload.tbirdbld.productdelivery.prod.mozaws.net: IGW
+            upload.seabld.productdelivery.prod.mozaws.net: IGW
             upload.ffxbld.productdelivery.stage.mozaws.net: IGW
             upload.tbirdbld.productdelivery.stage.mozaws.net: IGW
+            upload.seabld.productdelivery.stage.mozaws.net: IGW
 
             10.134.0.0/16: local
             0.0.0.0/0: VGW


### PR DESCRIPTION
Needed to add us-east for the actual machines upload ability, and to make firewall-tests less complex/annoying I decided might as well open up the flow from our masters (even though I have no plans to actually need it, there is 0 harm imo, since productdelivery is still completely mozilla controlled)