### PR TITLE
Bug1252248 - Add more tst-linux64, tst-emulator64 capacity in AWS

### DIFF
--- a/configs/subnets.yml
+++ b/configs/subnets.yml
@@ -16,6 +16,10 @@ us-west-2:
             name: test
             routing_table: testers
 
+        10.132.60.0/22:
+            name: test
+            routing_table: testers
+
         10.132.64.0/22:
             name: try
             routing_table: try
@@ -60,6 +64,10 @@ us-east-1:
             routing_table: builders
 
         10.134.56.0/22:
+            name: test
+            routing_table: testers
+
+        10.132.60.0/22:
             name: test
             routing_table: testers
 

--- a/configs/watch_pending.cfg
+++ b/configs/watch_pending.cfg
@@ -217,7 +217,7 @@
             "global": {
                 "tst-linux64": 3000,
                 "tst-linux32": 999,
-                "tst-emulator64": 1600,
+                "tst-emulator64": 1550,
                 "bld-linux64": 600,
                 "av-linux64": 2,
                 "b-2008": 200,

--- a/configs/watch_pending.cfg
+++ b/configs/watch_pending.cfg
@@ -215,9 +215,9 @@
         },
         "limits": {
             "global": {
-                "tst-linux64": 2500,
+                "tst-linux64": 3000,
                 "tst-linux32": 999,
-                "tst-emulator64": 1300,
+                "tst-emulator64": 1600,
                 "bld-linux64": 600,
                 "av-linux64": 2,
                 "b-2008": 200,
@@ -225,9 +225,9 @@
                 "t-w732": 400
             },
             "us-east-1": {
-                "tst-linux64": 1200,
+                "tst-linux64": 1450,
                 "tst-linux32": 666,
-                "tst-emulator64": 1000,
+                "tst-emulator64": 1125,
                 "bld-linux64": 400,
                 "av-linux64": 1,
                 "try-linux64": 200,
@@ -236,9 +236,9 @@
                 "t-w732": 200
             },
             "us-west-2": {
-                "tst-linux64": 1200,
+                "tst-linux64": 1450,
                 "tst-linux32": 666,
-                "tst-emulator64": 1000,
+                "tst-emulator64": 1125,
                 "bld-linux64": 400,
                 "av-linux64": 1,
                 "try-linux64": 200,


### PR DESCRIPTION
The changes have been tested locally without any issue