### PR TITLE
Bug 1249527 - Investigate quicker recovery from mass-termination

### DIFF
--- a/cloudtools/aws/spot.py
+++ b/cloudtools/aws/spot.py
@@ -191,7 +191,8 @@ def get_available_slave_name(region, moz_instance_type, is_spot,
     else:
         # populate cache and call again
         all_slave_names = get_classified_slaves(is_spot)
-        all_used_names = set(i.tags.get("Name") for i in all_instances)
+        all_used_names = set(i.tags.get("Name") for i in all_instances if
+                             i.state != 'terminated')
         # used_spot_names contains pending too
         used_spot_names = set(r.tags.get("Name") for r in
                               get_active_spot_requests(region))


### PR DESCRIPTION
…of AWS instances, eg bad golden ami and reverting to previous.

I think this should do the trick. All alternative would be filter at https://github.com/mozilla/build-cloud-tools/blob/master/cloudtools/scripts/aws_watch_pending.py#L446, but that's used in many places and I'm unsure if there would be any fallout.