### PR TITLE
Add current Cloudfront block for public-artifacts.taskcluster.net

### DIFF
--- a/configs/routingtables.yml
+++ b/configs/routingtables.yml
@@ -71,6 +71,8 @@ us-west-2:
             54.196.0.0/15: IGW
             # cloudfront for ftp/ftp-ssl/archive.m.o
             54.192.0.0/16: IGW
+            # public-artifacts.taskcluster.net
+            52.84.0.0/15
 
             # For graphite
             carbon.hostedgraphite.com: IGW
@@ -236,6 +238,8 @@ us-east-1:
             54.196.0.0/15: IGW
             # cloudfront for ftp/ftp-ssl/archive.m.o
             54.192.0.0/16: IGW
+            # public-artifacts.taskcluster.net
+            52.84.0.0/15
 
             # For graphite
             carbon.hostedgraphite.com: IGW


### PR DESCRIPTION
... to the configs for testers. I'd like to do something that uses https://ip-ranges.amazonaws.com/ip-ranges.json in the long term but this is the short term fix.