### PR TITLE
Watch for pending desktop l10n on try

### DIFF
--- a/configs/watch_pending.cfg
+++ b/configs/watch_pending.cfg
@@ -18,6 +18,8 @@
         "^b2g_(?!try)\\S+_linux(32|64)_gecko(-debug)?": "bld-linux64",
         "^Firefox (mozilla-central|mozilla-aurora|gum) linux(64)? l10n nightly": "bld-linux64",
         "^Firefox \\S+ win(32|64) l10n nightly": "b-2008",
+        "^Firefox try linux(32|64) l10n": "try-linxu64",
+        "^Firefox try win(32|64) l10n": "y-2008",
         "^Thunderbird (comm-central|comm-aurora) linux(64)? l10n nightly": "bld-linux64",
         "^Thunderbird \\S+ win(32|64) l10n nightly": "b-2008",
         "^graphene_(?!try)\\S+_linux(32|64)(-debug)?": "bld-linux64",


### PR DESCRIPTION
The new builder names are:
 Firefox try linux l10n
 Firefox try linux64 l10n
 Firefox try macosx64 l10n
 Firefox try win32 l10n
 Firefox try win64 l10n
