### PR TITLE
Bug 1281199 - Fix product type when requesting spot prices

### DIFF
--- a/cloudtools/scripts/aws_watch_pending.py
+++ b/cloudtools/scripts/aws_watch_pending.py
@@ -137,8 +137,6 @@ def aws_resume_instances(all_instances, moz_instance_type, start_count,
 def get_product_description(moz_instance_type):
     # http://docs.aws.amazon.com/sdkforruby/api/Aws/EC2/Types/DescribeReservedInstancesOfferingsRequest.html
     # https://boto3.readthedocs.org/en/latest/reference/services/ec2.html#EC2.Client.request_spot_instances
-    if moz_instance_type in ["y-2008", "b-2008", "t-w732", "g-w732"]:
-        return "Windows (Amazon VPC)"
     return "Linux/UNIX (Amazon VPC)"
 
 


### PR DESCRIPTION
At some point we switched from using Windows instances in AWS to using
Linux instances, but neglected to update the product description. This
meant we were looking at Windows spot price history to find the
cheapest region, and then requesting Linux instances in those regions.