### PR TITLE
bug 1286549 - disable puppet service (t-w732); r=markco

### DIFF
--- a/configs/Ec2UserdataUtils.psm1
+++ b/configs/Ec2UserdataUtils.psm1
@@ -1610,7 +1610,6 @@ function Install-RelOpsPrerequisites {
   if ($env:ComputerName.Contains('-w732-')) {
     Install-Package -id 'puppet' -version '3.4.3' -testPath ('{0}\Puppet Labs\Puppet\bin\puppet.bat' -f $env:ProgramFiles)
     Disable-Service -serviceName 'puppet'
-    Remove-ItemProperty -Name 'fPromptForPassword' -Path 'HKLM:\Software\Policies\Microsoft\Windows NT\Terminal Services' -ErrorAction SilentlyContinue
   }
   
   #https://bugzilla.mozilla.org/show_bug.cgi?id=1261812

--- a/configs/Ec2UserdataUtils.psm1
+++ b/configs/Ec2UserdataUtils.psm1
@@ -1609,6 +1609,8 @@ function Install-RelOpsPrerequisites {
   Install-Package -id 'sublimetext3.packagecontrol' -version '2.0.0.20140915' -testPath ('{0}\Sublime Text 3\Installed Packages\Package Control.sublime-package' -f $env:AppData)
   if ($env:ComputerName.Contains('-w732-')) {
     Install-Package -id 'puppet' -version '3.4.3' -testPath ('{0}\Puppet Labs\Puppet\bin\puppet.bat' -f $env:ProgramFiles)
+    Disable-Service -serviceName 'puppet'
+    Remove-ItemProperty -Name 'fPromptForPassword' -Path 'HKLM:\Software\Policies\Microsoft\Windows NT\Terminal Services'
   }
   
   #https://bugzilla.mozilla.org/show_bug.cgi?id=1261812

--- a/configs/Ec2UserdataUtils.psm1
+++ b/configs/Ec2UserdataUtils.psm1
@@ -1610,7 +1610,7 @@ function Install-RelOpsPrerequisites {
   if ($env:ComputerName.Contains('-w732-')) {
     Install-Package -id 'puppet' -version '3.4.3' -testPath ('{0}\Puppet Labs\Puppet\bin\puppet.bat' -f $env:ProgramFiles)
     Disable-Service -serviceName 'puppet'
-    Remove-ItemProperty -Name 'fPromptForPassword' -Path 'HKLM:\Software\Policies\Microsoft\Windows NT\Terminal Services'
+    Remove-ItemProperty -Name 'fPromptForPassword' -Path 'HKLM:\Software\Policies\Microsoft\Windows NT\Terminal Services' -ErrorAction SilentlyContinue
   }
   
   #https://bugzilla.mozilla.org/show_bug.cgi?id=1261812


### PR DESCRIPTION
The `Disable-Service -serviceName 'puppet'` line here should stop and disable the running puppet service. For golden runs we use the puppet agent cli rather than the service, so there's no good reason for it to be running.
The `Remove-ItemProperty -Name 'fPromptForPassword' -Path 'HKLM:\Software\Policies\Microsoft\Windows NT\Terminal Services'` line is a piggyback change to change the rdp service behaviour to allow rdp clients to authenticate from the command line (as all our other windows instances allow)